### PR TITLE
feat(profile): 키/몸무게/전신사진 필드 추가 및 Setup3 페이지 생성

### DIFF
--- a/closzIT-back/prisma/schema/user.prisma
+++ b/closzIT-back/prisma/schema/user.prisma
@@ -37,6 +37,12 @@ model User {
   updatedAt          DateTime       @updatedAt @map("updated_at")
   /// 시/도 (한글 직접 저장)
   province           String?
+  /// 키 (cm)
+  height             Decimal?       @db.Decimal
+  /// 몸무게 (kg)
+  weight             Decimal?       @db.Decimal
+  /// 체형
+  bodyType           String?        @map("body_type")
   clothes            Clothing[]
 
   @@map("users")

--- a/closzIT-back/src/user/dto/update-profile.dto.ts
+++ b/closzIT-back/src/user/dto/update-profile.dto.ts
@@ -11,6 +11,11 @@ export class UpdateProfileDto {
   // Setup 2 정보
   hairColor?: string;
   personalColor?: string;
+  height?: number;
+  weight?: number;
   bodyType?: string;
   preferredStyles?: string[];
+
+  // Setup 3 정보
+  fullBodyImage?: string; // Base64 encoded image
 }

--- a/closzIT-back/src/user/user.service.ts
+++ b/closzIT-back/src/user/user.service.ts
@@ -60,7 +60,13 @@ export class UserService {
     // Setup 2 정보 업데이트
     if (updateProfileDto.hairColor !== undefined) updateData.hairColor = updateProfileDto.hairColor;
     if (updateProfileDto.personalColor !== undefined) updateData.personalColor = updateProfileDto.personalColor;
+    if (updateProfileDto.height !== undefined) updateData.height = updateProfileDto.height;
+    if (updateProfileDto.weight !== undefined) updateData.weight = updateProfileDto.weight;
+    if (updateProfileDto.bodyType !== undefined) updateData.bodyType = updateProfileDto.bodyType;
     if (updateProfileDto.preferredStyles !== undefined) updateData.preferredStyles = updateProfileDto.preferredStyles;
+
+    // Setup 3 정보 업데이트
+    if (updateProfileDto.fullBodyImage !== undefined) updateData.fullBodyImage = updateProfileDto.fullBodyImage;
 
     // 프로필 완성 여부 체크
     const updatedName = updateData.name ?? user.name;

--- a/closzIT-front/src/App.js
+++ b/closzIT-front/src/App.js
@@ -4,6 +4,7 @@ import LoginPage from './pages/Login/LoginPage';
 import AuthCallbackPage from './pages/Login/AuthCallbackPage';
 import UserProfileSetup1 from './pages/UserProfileSetup/UserProfileSetup1';
 import UserProfileSetup2 from './pages/UserProfileSetup/UserProfileSetup2';
+import UserProfileSetup3 from './pages/UserProfileSetup/UserProfileSetup3';
 import MainPage from './pages/Main/MainPage';
 import MyPage from './pages/MyPage/MyPage';
 import RegisterPage from './pages/Register/RegisterPage';
@@ -20,6 +21,9 @@ function App() {
         <Route path="/auth/callback" element={<AuthCallbackPage />} />
         <Route path="/setup/profile1" element={<UserProfileSetup1 />} />
         <Route path="/setup/profile2" element={<UserProfileSetup2 />} />
+        <Route path="/setup2" element={<UserProfileSetup2 />} />
+        <Route path="/setup3" element={<UserProfileSetup3 />} />
+        <Route path="/setup/profile3" element={<UserProfileSetup3 />} />
         <Route path="/main" element={<MainPage />} />
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/register" element={<RegisterPage />} />

--- a/closzIT-front/src/pages/UserProfileSetup/UserProfileSetup2.jsx
+++ b/closzIT-front/src/pages/UserProfileSetup/UserProfileSetup2.jsx
@@ -9,6 +9,8 @@ const UserProfileSetup2 = () => {
   // State 관리
   const [hairColor, setHairColor] = useState('');
   const [personalColor, setPersonalColor] = useState('');
+  const [height, setHeight] = useState('');
+  const [weight, setWeight] = useState('');
   const [bodyType, setBodyType] = useState('');
   const [preferredStyles, setPreferredStyles] = useState([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -30,6 +32,8 @@ const UserProfileSetup2 = () => {
           const userData = await response.json();
           if (userData.hairColor) setHairColor(userData.hairColor);
           if (userData.personalColor) setPersonalColor(userData.personalColor);
+          if (userData.height) setHeight(String(userData.height));
+          if (userData.weight) setWeight(String(userData.weight));
           if (userData.bodyType) setBodyType(userData.bodyType);
           if (userData.preferredStyles && userData.preferredStyles.length > 0) {
             setPreferredStyles(userData.preferredStyles);
@@ -52,8 +56,29 @@ const UserProfileSetup2 = () => {
     );
   };
 
-  // 폼 제출 핸들러
-  const handleSubmit = async () => {
+  // 폼 제출 핸들러 - Setup3로 이동
+  const handleSubmit = () => {
+    // Setup2 데이터를 localStorage에 저장
+    const setup2Data = {
+      hairColor,
+      personalColor,
+      height: height ? parseFloat(height) : null,
+      weight: weight ? parseFloat(weight) : null,
+      bodyType,
+      preferredStyles
+    };
+    localStorage.setItem('userProfileSetup2', JSON.stringify(setup2Data));
+    
+    // edit 모드면 바로 저장, 아니면 Setup3로 이동
+    if (isEditMode) {
+      saveProfileToBackend();
+    } else {
+      navigate('/setup3');
+    }
+  };
+
+  // 백엔드에 프로필 저장 (edit 모드용)
+  const saveProfileToBackend = async () => {
     setIsSubmitting(true);
     setError('');
 
@@ -76,6 +101,8 @@ const UserProfileSetup2 = () => {
         city: setup1Data.city,
         hairColor,
         personalColor,
+        height: height ? parseFloat(height) : null,
+        weight: weight ? parseFloat(weight) : null,
         bodyType,
         preferredStyles
       };
@@ -94,8 +121,7 @@ const UserProfileSetup2 = () => {
         throw new Error('프로필 저장에 실패했습니다');
       }
 
-      // 성공 시 - edit 모드면 마이페이지로, 아니면 메인으로
-      navigate(isEditMode ? '/mypage' : '/main');
+      navigate('/mypage');
     } catch (err) {
       console.error('Profile update error:', err);
       setError(err.message || '오류가 발생했습니다');
@@ -269,6 +295,43 @@ const UserProfileSetup2 = () => {
                                 진단받기
                                 <span className="material-icons-round text-base">arrow_forward</span>
                             </button>
+                        </div>
+                    </div>
+                </section>
+
+                {/* 키/몸무게 입력 (선택) */}
+                <section className="space-y-3">
+                    <div className="flex items-center gap-2">
+                        <label className="block text-base font-semibold text-gray-800 dark:text-gray-200">
+                            키와 몸무게
+                        </label>
+                        <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">
+                            선택
+                        </span>
+                    </div>
+                    <p className="text-sm text-gray-500 dark:text-gray-400 -mt-1">
+                        더 정확한 스타일 추천을 위해 입력해주세요 (안 해도 괜찮아요!)
+                    </p>
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="relative">
+                            <input
+                                type="number"
+                                placeholder="키 (cm)"
+                                value={height}
+                                onChange={(e) => setHeight(e.target.value)}
+                                className="w-full px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-surface-light dark:bg-surface-dark text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all"
+                            />
+                            <span className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 text-sm">cm</span>
+                        </div>
+                        <div className="relative">
+                            <input
+                                type="number"
+                                placeholder="몸무게 (kg)"
+                                value={weight}
+                                onChange={(e) => setWeight(e.target.value)}
+                                className="w-full px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-surface-light dark:bg-surface-dark text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all"
+                            />
+                            <span className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 text-sm">kg</span>
                         </div>
                     </div>
                 </section>

--- a/closzIT-front/src/pages/UserProfileSetup/UserProfileSetup3.jsx
+++ b/closzIT-front/src/pages/UserProfileSetup/UserProfileSetup3.jsx
@@ -1,0 +1,330 @@
+import React, { useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const UserProfileSetup3 = () => {
+  const navigate = useNavigate();
+  const fileInputRef = useRef(null);
+  
+  // State 관리
+  const [fullBodyImage, setFullBodyImage] = useState(null);
+  const [imagePreview, setImagePreview] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  // 이미지 압축 함수
+  const compressImage = (file, maxWidth = 800, quality = 0.7) => {
+    return new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const img = new Image();
+        img.onload = () => {
+          const canvas = document.createElement('canvas');
+          let width = img.width;
+          let height = img.height;
+
+          // 비율 유지하면서 리사이즈
+          if (width > maxWidth) {
+            height = (height * maxWidth) / width;
+            width = maxWidth;
+          }
+
+          canvas.width = width;
+          canvas.height = height;
+
+          const ctx = canvas.getContext('2d');
+          ctx.drawImage(img, 0, 0, width, height);
+
+          // Base64로 변환
+          const compressedBase64 = canvas.toDataURL('image/jpeg', quality);
+          resolve(compressedBase64);
+        };
+        img.src = event.target.result;
+      };
+      reader.readAsDataURL(file);
+    });
+  };
+
+  // 파일 선택 핸들러
+  const handleFileSelect = async (event) => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    // 이미지 파일 검증
+    if (!file.type.startsWith('image/')) {
+      setError('이미지 파일만 업로드 가능합니다');
+      return;
+    }
+
+    try {
+      // 이미지 압축 (최대 800px, 품질 70%)
+      const compressedImage = await compressImage(file, 800, 0.7);
+      setFullBodyImage(compressedImage);
+      setImagePreview(compressedImage);
+      setError('');
+    } catch (err) {
+      console.error('Image compression error:', err);
+      setError('이미지 처리 중 오류가 발생했습니다');
+    }
+  };
+
+  // 카메라 촬영 핸들러
+  const handleCameraCapture = () => {
+    fileInputRef.current.click();
+  };
+
+  // 이미지 삭제
+  const handleRemoveImage = () => {
+    setFullBodyImage(null);
+    setImagePreview(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  // 건너뛰기
+  const handleSkip = async () => {
+    await submitProfile(null);
+  };
+
+  // 프로필 제출
+  const submitProfile = async (imageData) => {
+    setIsSubmitting(true);
+    setError('');
+
+    try {
+      const token = localStorage.getItem('accessToken');
+      const setup1Data = JSON.parse(localStorage.getItem('userProfile') || '{}');
+      const setup2Data = JSON.parse(localStorage.getItem('userProfileSetup2') || '{}');
+      
+      // 생년월일 포맷 변환
+      let birthday = null;
+      if (setup1Data.birthday) {
+        const { year, month, day } = setup1Data.birthday;
+        birthday = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+      }
+
+      const profileData = {
+        // Setup 1 데이터
+        name: setup1Data.name,
+        gender: setup1Data.gender,
+        birthday,
+        province: setup1Data.province,
+        city: setup1Data.city,
+        // Setup 2 데이터
+        hairColor: setup2Data.hairColor,
+        personalColor: setup2Data.personalColor,
+        height: setup2Data.height,
+        weight: setup2Data.weight,
+        bodyType: setup2Data.bodyType,
+        preferredStyles: setup2Data.preferredStyles || [],
+        // Setup 3 데이터
+        fullBodyImage: imageData
+      };
+
+      const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000';
+      const response = await fetch(`${backendUrl}/user/profile`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify(profileData)
+      });
+
+      if (!response.ok) {
+        throw new Error('프로필 저장에 실패했습니다');
+      }
+
+      // localStorage 정리
+      localStorage.removeItem('userProfile');
+      localStorage.removeItem('userProfileSetup2');
+
+      // 메인 페이지로 이동
+      navigate('/main');
+    } catch (err) {
+      console.error('Profile update error:', err);
+      setError(err.message || '오류가 발생했습니다');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // 완료 버튼 클릭
+  const handleComplete = async () => {
+    await submitProfile(fullBodyImage);
+  };
+
+  return (
+    <div className="min-h-screen bg-page-bg-light dark:bg-page-bg-dark">
+      {/* 헤더 */}
+      <header className="fixed top-0 left-0 right-0 z-50 bg-surface-light dark:bg-surface-dark border-b border-gray-100 dark:border-gray-800">
+        <div className="flex items-center justify-between px-4 h-14">
+          <button 
+            onClick={() => navigate('/setup2')}
+            className="w-10 h-10 flex items-center justify-center -ml-2"
+          >
+            <span className="material-icons-round text-gray-600 dark:text-gray-300">arrow_back</span>
+          </button>
+          <h1 className="text-lg font-bold text-gray-900 dark:text-white">회원정보 입력</h1>
+          <div className="w-10"></div>
+        </div>
+        
+        {/* 프로그레스 바 */}
+        <div className="h-1 bg-gray-200 dark:bg-gray-700">
+          <div className="h-full bg-brand-blue transition-all duration-300" style={{ width: '100%' }}></div>
+        </div>
+      </header>
+
+      {/* 메인 컨텐츠 */}
+      <main className="pt-16 pb-32 px-6">
+        <div className="max-w-md mx-auto space-y-8 mt-6">
+          {/* 안내 텍스트 */}
+          <div className="text-center space-y-2">
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white">
+              전신 사진을 등록해주세요
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              가상 피팅에 사용될 사진이에요
+            </p>
+            <div className="flex items-center justify-center gap-2 mt-2">
+              <span className="text-xs px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">
+                선택사항
+              </span>
+              <span className="text-xs text-gray-400">
+                나중에 등록해도 괜찮아요
+              </span>
+            </div>
+          </div>
+
+          {/* 이미지 업로드 영역 */}
+          <section className="space-y-4">
+            {!imagePreview ? (
+              <div 
+                onClick={handleCameraCapture}
+                className="w-full aspect-[3/4] max-w-xs mx-auto rounded-2xl border-2 border-dashed border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 flex flex-col items-center justify-center cursor-pointer hover:border-brand-blue hover:bg-blue-50/50 dark:hover:bg-blue-900/20 transition-all"
+              >
+                <div className="w-20 h-20 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center mb-4">
+                  <span className="material-icons-round text-4xl text-gray-400">person</span>
+                </div>
+                <span className="text-sm font-medium text-gray-600 dark:text-gray-300">
+                  사진을 선택해주세요
+                </span>
+                <span className="text-xs text-gray-400 mt-1">
+                  전신이 보이는 사진을 권장해요
+                </span>
+              </div>
+            ) : (
+              <div className="relative w-full aspect-[3/4] max-w-xs mx-auto rounded-2xl overflow-hidden shadow-lg">
+                <img 
+                  src={imagePreview} 
+                  alt="전신 사진 미리보기" 
+                  className="w-full h-full object-cover"
+                />
+                <button
+                  onClick={handleRemoveImage}
+                  className="absolute top-3 right-3 w-8 h-8 rounded-full bg-black/50 flex items-center justify-center hover:bg-black/70 transition-colors"
+                >
+                  <span className="material-icons-round text-white text-lg">close</span>
+                </button>
+              </div>
+            )}
+
+            {/* 파일 입력 (숨김) */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              capture="environment"
+              onChange={handleFileSelect}
+              className="hidden"
+            />
+
+            {/* 업로드 버튼들 */}
+            {!imagePreview && (
+              <div className="grid grid-cols-2 gap-3 max-w-xs mx-auto">
+                <button
+                  onClick={() => {
+                    fileInputRef.current.removeAttribute('capture');
+                    fileInputRef.current.click();
+                  }}
+                  className="flex items-center justify-center gap-2 py-3 px-4 rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+                >
+                  <span className="material-icons-round text-lg">photo_library</span>
+                  <span className="text-sm font-medium">앨범에서</span>
+                </button>
+                <button
+                  onClick={() => {
+                    fileInputRef.current.setAttribute('capture', 'environment');
+                    fileInputRef.current.click();
+                  }}
+                  className="flex items-center justify-center gap-2 py-3 px-4 rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+                >
+                  <span className="material-icons-round text-lg">photo_camera</span>
+                  <span className="text-sm font-medium">촬영하기</span>
+                </button>
+              </div>
+            )}
+          </section>
+
+          {/* 안내 사항 */}
+          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-xl p-4">
+            <div className="flex gap-3">
+              <span className="text-amber-500 text-xl">💡</span>
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                  좋은 결과를 위한 팁
+                </p>
+                <ul className="text-xs text-amber-700 dark:text-amber-400 space-y-1 list-disc list-inside">
+                  <li>전신이 모두 나오도록 촬영해주세요</li>
+                  <li>정면을 바라보고 자연스러운 자세로</li>
+                  <li>밝은 조명에서 촬영하면 더 좋아요</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          {/* 에러 메시지 */}
+          {error && (
+            <div className="p-3 rounded-xl bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 text-sm text-center">
+              {error}
+            </div>
+          )}
+        </div>
+      </main>
+
+      {/* 하단 버튼 */}
+      <div className="fixed bottom-0 left-0 right-0 p-4 bg-surface-light dark:bg-surface-dark border-t border-gray-100 dark:border-gray-800 safe-area-bottom">
+        <div className="max-w-md mx-auto flex gap-3">
+          <button
+            onClick={handleSkip}
+            disabled={isSubmitting}
+            className="flex-1 py-4 rounded-xl font-bold text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+          >
+            건너뛰기
+          </button>
+          <button
+            onClick={handleComplete}
+            disabled={isSubmitting || !fullBodyImage}
+            className={`flex-1 py-4 rounded-xl font-bold text-white transition-all ${
+              fullBodyImage
+                ? 'bg-brand-blue hover:bg-blue-600'
+                : 'bg-gray-300 dark:bg-gray-600 cursor-not-allowed'
+            } disabled:opacity-50`}
+          >
+            {isSubmitting ? (
+              <span className="flex items-center justify-center gap-2">
+                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+                저장 중...
+              </span>
+            ) : '완료'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UserProfileSetup3;


### PR DESCRIPTION
## 📋 변경 요약

회원가입 프로필 설정에 키/몸무게/전신사진 필드를 추가하고, 새로운 Setup3 페이지를 생성했습니다.

## ✨ 주요 변경사항

### 🗄️ Backend (Prisma + NestJS)
- `user.prisma`: `height`, `weight`, `bodyType`, `fullBodyImage` 컬럼 추가
- `update-profile.dto.ts`: 새 필드들 DTO에 추가
- `user.service.ts`: 새 필드들 처리 로직 추가

### 🎨 Frontend (React)
- **UserProfileSetup2.jsx**: 
  - 키/몸무게 입력 UI 추가 (선택사항 표시)
  - 데이터를 localStorage에 저장 후 Setup3로 이동하도록 수정
- **UserProfileSetup3.jsx (신규)**: 
  - 전신사진 업로드 페이지
  - 이미지 자동 압축 (최대 800px, JPEG 70%)
  - 건너뛰기 기능 지원
- **App.js**: `/setup3`, `/setup/profile3` 라우트 추가

## 📁 변경된 파일

| 파일 | 변경 내용 |
|------|----------|
| `closzIT-back/prisma/schema/user.prisma` | height, weight, bodyType, fullBodyImage 추가 |
| `closzIT-back/src/user/dto/update-profile.dto.ts` | height, weight, fullBodyImage 필드 추가 |
| `closzIT-back/src/user/user.service.ts` | 새 필드 처리 로직 |
| `closzIT-front/src/App.js` | Setup3 라우트 추가 |
| `closzIT-front/src/pages/UserProfileSetup/UserProfileSetup2.jsx` | 키/몸무게 UI, Setup3 이동 |
| `closzIT-front/src/pages/UserProfileSetup/UserProfileSetup3.jsx` | **신규** - 전신사진 업로드 |

## 🔄 회원가입 플로우

1. **Setup1** → 이름, 성별, 생년월일, 지역
2. **Setup2** → 머리색, 퍼스널컬러, 키/몸무게(선택), 체형, 스타일
3. **Setup3** → 전신사진 업로드(선택) → 모든 데이터 한번에 저장

## ✅ 머지 가이드라인

- 백엔드: `npx prisma generate` 실행 필요
- DB 스키마 변경 있음 (height, weight, body_type, full_body_image 컬럼)
