### PR TITLE
fix(items): 옷장에 자기 옷만 표시되도록 수정

### DIFF
--- a/closzIT-back/src/items/items.controller.ts
+++ b/closzIT-back/src/items/items.controller.ts
@@ -12,13 +12,13 @@ export class ItemsController {
     @Request() req,
     @Query('category') category?: string,
   ) {
-    const userId = req.user.userId;
+    const userId = req.user.id;
     return this.itemsService.getItemsByUser(userId, category);
   }
 
   @Get('by-category')
   async getItemsByCategory(@Request() req) {
-    const userId = req.user.userId;
+    const userId = req.user.id;
     return this.itemsService.getItemsGroupedByCategory(userId);
   }
 }


### PR DESCRIPTION
## 📋 변경 요약

메인 옷장에서 모든 사용자의 옷이 표시되던 버그를 수정했습니다. 이제 로그인한 사용자의 옷만 표시됩니다.

## 🐛 수정된 버그

**문제**: 메인 옷장에서 DB의 모든 옷이 표시됨 (사용자 구분 없이)

**원인**: `items.controller.ts`에서 `req.user.userId`를 사용했으나, JWT 전략이 전체 `User` 객체를 반환하므로 `userId` 프로퍼티가 `undefined`였음

**해결**: `req.user.id`로 변경

## 📁 변경된 파일

| 파일 | 변경 내용 |
|------|----------|
| `closzIT-back/src/items/items.controller.ts` | `req.user.userId` → `req.user.id`로 수정 |

## ✅ 테스트

- 로그인 후 메인 옷장에서 해당 사용자의 옷만 표시됨
- 다른 사용자의 옷은 표시되지 않음
