### PR TITLE
feat(의상복원): Gemini AI 기반 옷 펴기 기능 및 저장 로직 개선

### DIFF
--- a/closzIT-back/package-lock.json
+++ b/closzIT-back/package-lock.json
@@ -874,6 +874,7 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2572,6 +2573,7 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2727,6 +2729,7 @@
     "node_modules/@nestjs/common": {
       "version": "11.1.11",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.2.0",
         "iterare": "1.2.1",
@@ -2770,6 +2773,7 @@
       "version": "11.1.11",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2831,6 +2835,7 @@
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.11",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.2.1",
@@ -3763,6 +3768,7 @@
       "version": "9.6.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3875,6 +3881,7 @@
     "node_modules/@types/node": {
       "version": "22.19.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4055,6 +4062,7 @@
       "version": "8.50.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -4674,6 +4682,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4724,6 +4733,7 @@
       "version": "6.12.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4883,6 +4893,7 @@
     "node_modules/axios": {
       "version": "1.13.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -5100,6 +5111,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5274,6 +5286,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -5315,13 +5328,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5817,8 +5832,7 @@
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -5870,6 +5884,7 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5928,6 +5943,7 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6521,6 +6537,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7131,6 +7148,7 @@
       "version": "30.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8606,6 +8624,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -8739,6 +8758,7 @@
     "node_modules/pg": {
       "version": "8.16.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -8950,6 +8970,7 @@
       "version": "3.7.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9002,6 +9023,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -9125,7 +9147,8 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -9285,6 +9308,7 @@
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9805,6 +9829,7 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10091,6 +10116,7 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10218,6 +10244,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10543,7 +10570,6 @@
       "version": "2.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -10560,7 +10586,6 @@
       "version": "5.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -10572,7 +10597,6 @@
       "version": "5.1.1",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -10585,7 +10609,6 @@
       "version": "4.3.0",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -10593,14 +10616,12 @@
     "node_modules/webpack/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.52.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10609,7 +10630,6 @@
       "version": "2.1.35",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -10621,7 +10641,6 @@
       "version": "4.3.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/closzIT-back/prisma/schema/clothing.prisma
+++ b/closzIT-back/prisma/schema/clothing.prisma
@@ -14,6 +14,9 @@ model Clothing {
   /// 예: https://s3.../clothes/user_123/blazer_001.png
   imageUrl String @map("image_url")
 
+  /// 펼쳐진 의상 이미지 URL (옷 펴기 기능 사용 시 저장)
+  flattenImageUrl String? @map("flatten_image_url")
+
   // ===== 카테고리 =====
 
   /// 대분류: Outer, Top, Bottom, Shoes, Other

--- a/closzIT-back/src/analysis/analysis.controller.ts
+++ b/closzIT-back/src/analysis/analysis.controller.ts
@@ -43,4 +43,35 @@ export class AnalysisController {
     async deleteItem(@Param('id') id: string) {
         return this.analysisService.deleteItem(parseInt(id));
     }
+
+    @Post('flatten')
+    async flattenClothing(@Body() body: {
+        image_base64: string;
+        category?: string;
+        sub_category?: string;
+        colors?: string[];
+        pattern?: string[];
+        detail?: string[];
+        style_mood?: string[];
+    }) {
+        this.logger.log(`[flattenClothing] Request received for category: ${body.category}/${body.sub_category}`);
+
+        try {
+            const result = await this.analysisService.flattenClothing(
+                body.image_base64,
+                body.category,
+                body.sub_category,
+                {
+                    colors: body.colors || [],
+                    pattern: body.pattern || [],
+                    detail: body.detail || [],
+                    style_mood: body.style_mood || [],
+                }
+            );
+            return result;
+        } catch (error) {
+            this.logger.error(`[flattenClothing] Error:`, error.message || error);
+            throw error;
+        }
+    }
 }

--- a/closzIT-back/src/items/items.service.ts
+++ b/closzIT-back/src/items/items.service.ts
@@ -3,7 +3,7 @@ import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class ItemsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(private prisma: PrismaService) { }
 
   async getItemsByUser(userId: string, category?: string) {
     const where: any = { userId };
@@ -20,6 +20,7 @@ export class ItemsService {
       select: {
         id: true,
         imageUrl: true,
+        flattenImageUrl: true,
         category: true,
         subCategory: true,
         colors: true,
@@ -39,7 +40,10 @@ export class ItemsService {
     return items.map(item => ({
       id: item.id,
       name: item.subCategory,
-      image: item.imageUrl,
+      // 펼쳐진 이미지가 있으면 우선 사용, 없으면 원본 이미지
+      image: item.flattenImageUrl || item.imageUrl,
+      originalImage: item.imageUrl,
+      flattenImage: item.flattenImageUrl,
       category: item.category,
       subCategory: item.subCategory,
       colors: item.colors,


### PR DESCRIPTION
## 📋 개요
Gemini AI를 활용한 의상 복원(옷 펴기) 기능을 구현하고, 관련 저장 로직을 개선했습니다.

## ✨ 주요 변경사항

### Frontend (`LabelingPage.jsx`)

#### 의상 복원 UI 구현
- **"옷 펴기" 버튼**: 분석된 의상 이미지를 Gemini AI를 통해 평면 전개(flat-lay) 이미지로 변환
- **펼쳐진 이미지 미리보기**: 생성된 이미지를 즉시 확인 가능
- **이미지 확대 모달**: 원본/분석/펼쳐진 이미지를 클릭하여 확대 보기
- **제외/포함 토글**: 펼쳐진 이미지도 X 버튼으로 저장에서 제외 가능

#### 애니메이션 효과
- 확대 모달에 `fadeIn`, `scaleIn` 애니메이션 적용

#### 저장 로직 개선
- 펼쳐진 이미지(`flatten_image_base64`)를 저장 요청에 포함

---

### Backend (`analysis.service.ts`)

#### `flattenClothing()` 메서드 구현
- **Gemini AI 활용**: `gemini-3-pro-image-preview` 모델 사용
- **카테고리별 특화 프롬프트**:
  - Top/Outer: 소매를 양옆으로 펼친 T자 형태
  - Bottom: 양 다리를 아래로 펼친 형태
  - Shoes: 양쪽 신발을 나란히 배치
- **세로 방향 강제**: 이커머스 썸네일에 적합한 포트레이트 방향
- **라벨 정보 반영**: 색상, 패턴, 디테일, 스타일 무드를 프롬프트에 포함하여 정확도 향상

#### `saveItems()` 개선
- `flatten_image_url` 컬럼에 펼쳐진 이미지 저장

---

### Backend (`items.service.ts`)

#### 응답 구조 개선
- `flattenImageUrl`이 있으면 기본 `image` 필드로 우선 사용
- `originalImage`, `flattenImage` 필드를 별도 제공하여 프론트엔드에서 선택적 사용 가능

---

## 📁 변경된 파일 목록
| 파일 | 변경 유형 | 설명 |
|------|----------|------|
| `closzIT-front/src/pages/Labeling/LabelingPage.jsx` | 수정 | 의상 복원 UI 및 모달 애니메이션 추가 |
| `closzIT-back/src/analysis/analysis.service.ts` | 수정 | Gemini AI 기반 flattenClothing() 구현 |
| `closzIT-back/src/items/items.service.ts` | 수정 | 펼쳐진 이미지 필드 추가 |

---

## 🧪 테스트 방법
1. 프론트엔드에서 이미지를 업로드하고 "의상 분석" 실행
2. 분석 결과 오른쪽의 "옷 펴기" 버튼 클릭
3. 생성된 펼쳐진 이미지 확인 (클릭하여 확대 가능)
4. 필요시 X 버튼으로 저장에서 제외
5. "모든 의상 저장" 버튼으로 DB 저장
6. 옷장 페이지에서 펼쳐진 이미지가 기본 표시되는지 확인

---

## 🔗 관련 이슈
- #39 의상 복원 기능 추가
