### PR TITLE
ci(deploy): update pm2 process name

### DIFF
--- a/.github/workflows/deploy-back.yml
+++ b/.github/workflows/deploy-back.yml
@@ -28,6 +28,6 @@ jobs:
               "sudo -i -u ubuntu bash -c \"cd /home/ubuntu/app && git pull origin dev\"",
               "sudo -i -u ubuntu bash -c \"cd /home/ubuntu/app/closzIT-back && npm install\"",
               "sudo -i -u ubuntu bash -c \"cd /home/ubuntu/app/closzIT-back && npm run build\"",
-              "sudo -i -u ubuntu bash -c \"cd /home/ubuntu/app/closzIT-back && pm2 restart all || pm2 start dist/main.js --name backend\""
+              "sudo -i -u ubuntu bash -c \"cd /home/ubuntu/app/closzIT-back && pm2 restart all || pm2 start dist/main.js --name closzIT-backend\""
             ]' \
             --comment "Deploying backend from closzIT-back directory"


### PR DESCRIPTION
# 🔀 변경 사항
- GitHub Actions 배포 워크플로우(`deploy-back.yml`)에서 PM2 프로세스 이름을 `backend`에서 `closzIT-backend`로 변경했습니다.

# 📄 변경된 파일
- `.github/workflows/deploy-back.yml`: PM2 프로세스 이름 수정

# 💡 참고 사항
- 배포 스크립트 실행 시 프로세스 이름 불일치로 인한 오류를 방지하기 위함입니다.
