### PR TITLE
fix(front): 브라우저 탭 제목을 CloszIT으로 변경

### DIFF
--- a/closzIT-front/public/index.html
+++ b/closzIT-front/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#FAF8F5" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="CloszIT - 내 손안의 스마트 옷장"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!-- Fonts -->
@@ -29,7 +29,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>CloszIT</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## 변경 사항
배포 시 브라우저 탭에 "React App" 대신 **CloszIT**이 표시되도록 수정

## 수정 내용
- `index.html`의 `<title>` 태그: `React App` → `CloszIT`
- `index.html`의 meta description: `CloszIT - 내 손안의 스마트 옷장`

## 변경 파일
- `closzIT-front/public/index.html`

## 테스트
- [x] 로컬에서 브라우저 탭 제목 확인

## 머지 가이드라인
- 배포 후 브라우저 탭 및 북마크에서 "CloszIT - closzit.shop"으로 표시됩니다
