### PR TITLE
feat: 부분 가상 피팅 및 메인 페이지 UI 개선

### DIFF
--- a/closzIT-back/src/fitting/fitting.controller.ts
+++ b/closzIT-back/src/fitting/fitting.controller.ts
@@ -66,6 +66,57 @@ export class FittingController {
     return result;
   }
 
+  @Post('partial-try-on')
+  @UseInterceptors(
+    FileFieldsInterceptor([
+      { name: 'person', maxCount: 1 },
+      { name: 'outer', maxCount: 1 },
+      { name: 'top', maxCount: 1 },
+      { name: 'bottom', maxCount: 1 },
+      { name: 'shoes', maxCount: 1 },
+    ]),
+  )
+  async partialTryOn(
+    @Request() req,
+    @UploadedFiles()
+    files: {
+      person?: Express.Multer.File[];
+      outer?: Express.Multer.File[];
+      top?: Express.Multer.File[];
+      bottom?: Express.Multer.File[];
+      shoes?: Express.Multer.File[];
+    },
+  ) {
+    const userId = req.user.id;
+    console.log('Partial VTO Request - userId:', userId);
+
+    // person 이미지는 필수
+    if (!files.person?.[0]) {
+      throw new BadRequestException('전신 사진(person)은 필수입니다.');
+    }
+
+    // 최소 1개 이상의 의류 이미지가 있어야 함
+    const hasOuter = !!files.outer?.[0];
+    const hasTop = !!files.top?.[0];
+    const hasBottom = !!files.bottom?.[0];
+    const hasShoes = !!files.shoes?.[0];
+
+    if (!hasOuter && !hasTop && !hasBottom && !hasShoes) {
+      throw new BadRequestException('최소 1개 이상의 의류 이미지가 필요합니다.');
+    }
+
+    const imageMap = {
+      person: files.person[0],
+      outer: files.outer?.[0] || null,
+      top: files.top?.[0] || null,
+      bottom: files.bottom?.[0] || null,
+      shoes: files.shoes?.[0] || null,
+    };
+
+    const result = await this.fittingService.processPartialFitting(imageMap, userId);
+    return result;
+  }
+
   @Post('check-status')
   async checkStatus(@Body() body: { jobId: string }) {
     return await this.fittingService.checkJobStatus(body.jobId);

--- a/closzIT-back/src/fitting/fitting.service.ts
+++ b/closzIT-back/src/fitting/fitting.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, HttpException, HttpStatus, Inject, forwardRef } from '@nestjs/common';
 import { GoogleGenAI } from '@google/genai';
+import { CreditTransactionType } from '@prisma/client';
 import { CreditService } from '../credit/credit.service';
 
 @Injectable()
@@ -172,6 +173,175 @@ Output ONLY the final image. No text or explanations.
           message: '가상 피팅 처리 중 오류가 발생했습니다',
           error: error.message,
           details: error.response?.data || error.toString(),
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
+    }
+  }
+
+  async processPartialFitting(images: {
+    person: Express.Multer.File;
+    outer: Express.Multer.File | null;
+    top: Express.Multer.File | null;
+    bottom: Express.Multer.File | null;
+    shoes: Express.Multer.File | null;
+  }, userId?: string) {
+    const startTime = Date.now();
+
+    try {
+      // VTO 사용 전 크레딧 차감 (2 크레딧 - 부분 피팅)
+      if (userId) {
+        try {
+          await this.creditService.deductCredit(userId, 2, CreditTransactionType.VTO_USED);
+          console.log(`Deducted 2 credits from user ${userId} for partial fitting`);
+        } catch (creditError) {
+          console.error('Failed to deduct credits:', creditError);
+          throw new HttpException(
+            {
+              success: false,
+              message: creditError.message || '크레딧이 부족합니다.',
+            },
+            HttpStatus.BAD_REQUEST
+          );
+        }
+      }
+
+      console.log('Starting partial virtual fitting with Gemini...');
+
+      // 전신 사진 base64 변환
+      const personBase64 = images.person.buffer.toString('base64');
+      
+      // 선택된 의류만 처리
+      const clothingParts: any[] = [];
+      const clothingDescriptions: string[] = [];
+      
+      if (images.outer) {
+        clothingParts.push({
+          inlineData: {
+            mimeType: 'image/jpeg',
+            data: images.outer.buffer.toString('base64'),
+          },
+        });
+        clothingDescriptions.push('outerwear (Image ' + (clothingParts.length + 1) + ')');
+      }
+      
+      if (images.top) {
+        clothingParts.push({
+          inlineData: {
+            mimeType: 'image/jpeg',
+            data: images.top.buffer.toString('base64'),
+          },
+        });
+        clothingDescriptions.push('top (Image ' + (clothingParts.length + 1) + ')');
+      }
+      
+      if (images.bottom) {
+        clothingParts.push({
+          inlineData: {
+            mimeType: 'image/jpeg',
+            data: images.bottom.buffer.toString('base64'),
+          },
+        });
+        clothingDescriptions.push('bottom (Image ' + (clothingParts.length + 1) + ')');
+      }
+      
+      if (images.shoes) {
+        clothingParts.push({
+          inlineData: {
+            mimeType: 'image/jpeg',
+            data: images.shoes.buffer.toString('base64'),
+          },
+        });
+        clothingDescriptions.push('shoes (Image ' + (clothingParts.length + 1) + ')');
+      }
+
+      // 동적 프롬프트 생성
+      const prompt = `
+Rules:
+1. SINGLE SUBJECT CONSTRAINT: 
+   - There is ONLY ONE PERSON in the final output, who must be the exact person from Image 1.
+   - Other images are for CLOTHING REFERENCE ONLY. Do not add extra people or create a collage.
+
+2. PERFECT PRESERVATION: 
+   - Maintain the identical face, expression, hair, body, and pose of the person in Image 1. 
+   - The background, lighting, and framing must remain 100% unchanged.
+   - Keep the person's ORIGINAL CLOTHES for any category not provided.
+
+3. CLOTHING ADAPTATION:
+   - Replace ONLY the following clothing items: ${clothingDescriptions.join(', ')}.
+   - Keep all other original clothing unchanged.
+   - Adjust the fabric's wrinkles and fit to match the person's specific pose and body shape naturally.
+
+Output ONLY the final image. No text or explanations.
+`;
+
+      const apiCallStartTime = Date.now();
+      const response = await (this.ai.models as any).generateContent({
+        model: 'gemini-3-pro-image-preview',
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              { text: prompt },
+              {
+                inlineData: {
+                  mimeType: 'image/jpeg',
+                  data: personBase64,
+                },
+              },
+              ...clothingParts,
+            ],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.1
+        },
+      });
+      const apiCallTime = (Date.now() - apiCallStartTime) / 1000;
+      const totalTime = (Date.now() - startTime) / 1000;
+
+      console.log(`Partial fitting API call time: ${apiCallTime.toFixed(2)}s`);
+      console.log(`Total processing time: ${totalTime.toFixed(2)}s`);
+
+      // 응답 처리
+      if (!response.candidates || response.candidates.length === 0) {
+        console.error('No candidates in response');
+        throw new Error('Gemini did not generate any candidates.');
+      }
+
+      const candidate = response.candidates[0];
+      if (!candidate.content || !candidate.content.parts) {
+        console.error('No content parts in candidate');
+        throw new Error('Invalid response structure from Gemini');
+      }
+
+      for (const part of candidate.content.parts) {
+        if (part.inlineData) {
+          const imageData = part.inlineData.data;
+          const dataUrl = `data:image/png;base64,${imageData}`;
+          console.log('Partial fitting image generated successfully');
+
+          return {
+            success: true,
+            imageUrl: dataUrl,
+            message: '부분 가상 피팅이 완료되었습니다',
+            itemsProcessed: clothingDescriptions,
+            processingTime: {
+              total: totalTime,
+              apiCall: apiCallTime,
+            },
+          };
+        }
+      }
+
+      throw new Error('No image data in Gemini response.');
+    } catch (error) {
+      console.error('Partial virtual fitting error:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: '부분 가상 피팅 처리 중 오류가 발생했습니다',
+          error: error.message,
         },
         HttpStatus.INTERNAL_SERVER_ERROR
       );

--- a/closzIT-front/src/App.js
+++ b/closzIT-front/src/App.js
@@ -10,6 +10,7 @@ import MyPage from './pages/MyPage/MyPage';
 import RegisterPage from './pages/Register/RegisterPage';
 import LabelingPage from './pages/Labeling/LabelingPage';
 import FittingPage from './pages/Fitting/FittingPage';
+import DirectFittingPage from './pages/Fitting/DirectFittingPage';
 import VirtualFittingTest from './pages/Fitting/VirtualFittingTest';
 import FeedPage from './pages/FeedPage';
 import CreatePostPage from './pages/CreatePostPage';
@@ -33,6 +34,7 @@ function App() {
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/labeling" element={<LabelingPage />} />
         <Route path="/fitting" element={<FittingPage />} />
+        <Route path="/fitting/direct" element={<DirectFittingPage />} />
         <Route path="/virtual-fitting-test" element={<VirtualFittingTest />} />
         <Route path="/feed" element={<FeedPage />} />
         <Route path="/create-post" element={<CreatePostPage />} />

--- a/closzIT-front/src/pages/Fitting/DirectFittingPage.jsx
+++ b/closzIT-front/src/pages/Fitting/DirectFittingPage.jsx
@@ -1,0 +1,287 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+const DirectFittingPage = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { outfit, fromMain } = location.state || {};
+
+  // 피팅 관련 상태
+  const [showCreditModal, setShowCreditModal] = useState(true);
+  const [isFitting, setIsFitting] = useState(false);
+  const [fittingResult, setFittingResult] = useState(null);
+  const [fittingError, setFittingError] = useState(null);
+  const [userFullBodyImage, setUserFullBodyImage] = useState(null);
+
+  // 선택된 옷 개수
+  const selectedCount = [outfit?.outerwear, outfit?.tops, outfit?.bottoms, outfit?.shoes].filter(Boolean).length;
+
+  // 사용자 전신 사진 가져오기
+  useEffect(() => {
+    if (!outfit || !fromMain || selectedCount === 0) {
+      navigate('/main');
+      return;
+    }
+
+    const fetchUserData = async () => {
+      try {
+        const token = localStorage.getItem('accessToken');
+        if (!token) {
+          navigate('/login');
+          return;
+        }
+
+        const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000';
+        const response = await fetch(`${backendUrl}/user/me`, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+
+        if (response.ok) {
+          const userData = await response.json();
+          if (!userData.fullBodyImage) {
+            setFittingError('전신 사진이 등록되지 않았습니다.');
+            setShowCreditModal(false);
+          } else {
+            setUserFullBodyImage(userData.fullBodyImage);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to fetch user data:', error);
+        setFittingError('사용자 정보를 불러오지 못했습니다.');
+        setShowCreditModal(false);
+      }
+    };
+
+    fetchUserData();
+  }, [outfit, fromMain, navigate]);
+
+  // base64를 Blob으로 변환
+  const base64ToBlob = (base64, mimeType = 'image/jpeg') => {
+    const byteString = atob(base64.split(',')[1]);
+    const ab = new ArrayBuffer(byteString.length);
+    const ia = new Uint8Array(ab);
+    for (let i = 0; i < byteString.length; i++) {
+      ia[i] = byteString.charCodeAt(i);
+    }
+    return new Blob([ab], { type: mimeType });
+  };
+
+  // URL에서 이미지를 Blob으로 가져오기
+  const urlToBlob = async (url) => {
+    const response = await fetch(url);
+    return await response.blob();
+  };
+
+  // 피팅 API 호출
+  const handleConfirmFitting = async () => {
+    setShowCreditModal(false);
+    setIsFitting(true);
+    setFittingError(null);
+
+    try {
+      const token = localStorage.getItem('accessToken');
+      const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000';
+      
+      const formData = new FormData();
+      
+      // 사용자 전신 사진 추가
+      const personBlob = base64ToBlob(userFullBodyImage);
+      formData.append('person', personBlob, 'person.jpg');
+      
+      // 선택된 의류 이미지들 추가
+      const processImage = async (item, key) => {
+        if (!item) return;
+        const imageUrl = item.image || item.imageUrl || item.image_url;
+        if (imageUrl.startsWith('data:')) {
+          formData.append(key, base64ToBlob(imageUrl), `${key}.jpg`);
+        } else {
+          const blob = await urlToBlob(imageUrl);
+          formData.append(key, blob, `${key}.jpg`);
+        }
+      };
+
+      await processImage(outfit.outerwear, 'outer');
+      await processImage(outfit.tops, 'top');
+      await processImage(outfit.bottoms, 'bottom');
+      await processImage(outfit.shoes, 'shoes');
+
+      const response = await fetch(`${backendUrl}/api/fitting/partial-try-on`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`
+        },
+        body: formData,
+      });
+
+      const data = await response.json();
+
+      if (data.success) {
+        setFittingResult(data);
+      } else {
+        setFittingError(data.message || '가상 피팅에 실패했습니다.');
+      }
+    } catch (err) {
+      console.error('Fitting error:', err);
+      setFittingError('피팅 처리 중 오류가 발생했습니다: ' + err.message);
+    } finally {
+      setIsFitting(false);
+    }
+  };
+
+  // 선택된 의류 표시용 배열
+  const outfitItems = [
+    outfit?.outerwear && { name: '외투', image: outfit.outerwear.image || outfit.outerwear.imageUrl },
+    outfit?.tops && { name: '상의', image: outfit.tops.image || outfit.tops.imageUrl },
+    outfit?.bottoms && { name: '하의', image: outfit.bottoms.image || outfit.bottoms.imageUrl },
+    outfit?.shoes && { name: '신발', image: outfit.shoes.image || outfit.shoes.imageUrl },
+  ].filter(Boolean);
+
+  return (
+    <div className="bg-cream dark:bg-[#1A1918] min-h-screen font-sans flex flex-col">
+      {/* Header */}
+      <div className="px-4 py-3 flex items-center justify-between gap-3 glass-warm border-b border-gold-light/20 sticky top-0 z-40">
+        <button 
+          onClick={() => fittingResult ? setFittingResult(null) : navigate('/main')}
+          className="w-10 h-10 -ml-2 rounded-full flex items-center justify-center hover:bg-gold-light/20 transition-colors"
+        >
+          <span className="material-symbols-rounded text-2xl text-charcoal dark:text-cream">arrow_back</span>
+        </button>
+        <h1 className="text-lg font-bold text-charcoal dark:text-cream">
+          {fittingResult ? '피팅 결과' : '가상 피팅'}
+        </h1>
+        <div className="w-10"></div>
+      </div>
+
+      {/* Main Content */}
+      <main className="flex-1 flex flex-col items-center justify-center py-6 px-4">
+        {/* 피팅 진행 중 */}
+        {isFitting && (
+          <div className="flex-1 flex flex-col items-center justify-center">
+            <div className="animate-spin rounded-full h-16 w-16 border-4 border-gold border-t-transparent mb-6"></div>
+            <p className="text-charcoal dark:text-cream font-medium text-lg">가상 피팅 중...</p>
+            <p className="text-sm text-charcoal-light dark:text-cream-dark mt-2">AI가 옷을 입혀보고 있어요</p>
+          </div>
+        )}
+
+        {/* 피팅 결과 */}
+        {fittingResult && !isFitting && (
+          <div className="flex-1 w-full max-w-md">
+            <div className="bg-warm-white dark:bg-charcoal rounded-2xl p-4 shadow-lifted border border-gold-light/20">
+              {fittingResult.imageUrl ? (
+                <>
+                  <img
+                    src={fittingResult.imageUrl}
+                    alt="Fitting Result"
+                    className="w-full rounded-xl mb-4"
+                  />
+                  <p className="text-sm text-charcoal-light dark:text-cream-dark text-center">
+                    처리 시간: {fittingResult.processingTime?.total?.toFixed(2) || '-'}초
+                  </p>
+                </>
+              ) : (
+                <>
+                  {fittingResult.note && (
+                    <div className="bg-gold/10 border-l-4 border-gold p-3 rounded-lg mb-4">
+                      <p className="text-sm text-charcoal dark:text-cream">{fittingResult.note}</p>
+                    </div>
+                  )}
+                  <div className="prose dark:prose-invert">
+                    <h3 className="text-lg font-semibold text-charcoal dark:text-cream mb-2">AI 분석 결과</h3>
+                    <p className="text-charcoal-light dark:text-cream-dark whitespace-pre-wrap">
+                      {fittingResult.description}
+                    </p>
+                  </div>
+                </>
+              )}
+            </div>
+            <button
+              onClick={() => navigate('/main')}
+              className="mt-6 w-full py-3 btn-premium rounded-xl font-bold"
+            >
+              홈으로 돌아가기
+            </button>
+          </div>
+        )}
+
+        {/* 에러 화면 */}
+        {fittingError && !isFitting && !fittingResult && (
+          <div className="flex-1 flex flex-col items-center justify-center">
+            <span className="material-symbols-rounded text-5xl text-red-400 mb-4">error</span>
+            <p className="text-charcoal dark:text-cream font-medium mb-2">피팅 실패</p>
+            <p className="text-sm text-charcoal-light dark:text-cream-dark mb-6 text-center">{fittingError}</p>
+            {!userFullBodyImage && (
+              <button
+                onClick={() => navigate('/setup3?edit=true')}
+                className="px-6 py-3 btn-premium rounded-xl font-semibold mb-3"
+              >
+                전신 사진 등록하기
+              </button>
+            )}
+            <button
+              onClick={() => navigate('/main')}
+              className="px-6 py-3 border border-gold text-gold rounded-xl font-semibold"
+            >
+              돌아가기
+            </button>
+          </div>
+        )}
+
+        {/* 선택된 옷 미리보기 (모달 전) */}
+        {!isFitting && !fittingResult && !fittingError && !showCreditModal && (
+          <div className="flex-1 w-full">
+            <div className="grid grid-cols-2 gap-4 mb-6">
+              {outfitItems.map((item, index) => (
+                <div key={index} className="bg-warm-white dark:bg-charcoal rounded-xl p-3 shadow-soft border border-gold-light/20">
+                  <img src={item.image} alt={item.name} className="w-full aspect-square object-cover rounded-lg mb-2" />
+                  <p className="text-center text-sm font-medium text-charcoal dark:text-cream">{item.name}</p>
+                </div>
+              ))}
+            </div>
+            <button
+              onClick={() => setShowCreditModal(true)}
+              className="w-full py-4 btn-premium rounded-xl font-bold text-lg"
+            >
+              피팅 시작하기
+            </button>
+          </div>
+        )}
+      </main>
+
+      {/* 크레딧 확인 모달 */}
+      {showCreditModal && userFullBodyImage && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-warm-white dark:bg-charcoal rounded-2xl p-6 max-w-sm w-full shadow-xl">
+            <div className="text-center mb-6">
+              <div className="w-16 h-16 rounded-full bg-gold/10 flex items-center justify-center mx-auto mb-4">
+                <span className="material-symbols-rounded text-3xl text-gold">monetization_on</span>
+              </div>
+              <h3 className="text-xl font-bold text-charcoal dark:text-cream mb-2">피팅 크레딧 사용</h3>
+              <p className="text-charcoal-light dark:text-cream-dark">
+                가상 피팅에 <span className="text-gold font-bold">2 크레딧</span>이 사용됩니다.
+              </p>
+              <p className="text-sm text-charcoal-light/70 dark:text-cream-dark/70 mt-2">
+                진행하시겠습니까?
+              </p>
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={() => navigate('/main')}
+                className="flex-1 py-3 rounded-xl border border-gold-light/30 text-charcoal dark:text-cream font-medium hover:bg-gold-light/10 transition-colors"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleConfirmFitting}
+                className="flex-1 py-3 rounded-xl btn-premium font-bold"
+              >
+                확인
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DirectFittingPage;

--- a/closzIT-front/src/pages/Fitting/FittingPage.jsx
+++ b/closzIT-front/src/pages/Fitting/FittingPage.jsx
@@ -10,15 +10,22 @@ const FittingPage = () => {
   const [context, setContext] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
+  
+  // 피팅 관련 상태
+  const [showCreditModal, setShowCreditModal] = useState(false);
+  const [isFitting, setIsFitting] = useState(false);
+  const [fittingResult, setFittingResult] = useState(null);
+  const [fittingError, setFittingError] = useState(null);
+  const [userFullBodyImage, setUserFullBodyImage] = useState(null);
 
-  // API에서 추천 받아오기
+  // API에서 추천 받아오기 + 사용자 전신 사진 가져오기
   useEffect(() => {
     if (!calendarEvent) {
       navigate('/');
       return;
     }
 
-    const fetchRecommendation = async () => {
+    const fetchData = async () => {
       try {
         const token = localStorage.getItem('accessToken');
         if (!token) {
@@ -27,6 +34,18 @@ const FittingPage = () => {
         }
 
         const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000';
+        
+        // 사용자 정보 가져오기 (전신 사진 포함)
+        const userResponse = await fetch(`${backendUrl}/user/me`, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        
+        if (userResponse.ok) {
+          const userData = await userResponse.json();
+          setUserFullBodyImage(userData.fullBodyImage);
+        }
+
+        // 코디 추천 받기
         const response = await fetch(`${backendUrl}/recommendation/search`, {
           method: 'POST',
           headers: {
@@ -41,10 +60,7 @@ const FittingPage = () => {
 
         if (response.ok) {
           const data = await response.json();
-          // 백엔드는 카테고리별 배열을 반환함
-          // { outer: [], top: [...], bottom: [...], shoes: [...] }
           if (data.results) {
-            // 각 카테고리에서 첫 번째 아이템을 가져와서 코디 세트 구성
             const outfitSet = {
               outer: data.results.outer?.[0] || null,
               top: data.results.top?.[0] || null,
@@ -52,7 +68,6 @@ const FittingPage = () => {
               shoes: data.results.shoes?.[0] || null,
             };
             
-            // 최소 1개 이상의 아이템이 있으면 outfit으로 설정
             const hasAnyItem = outfitSet.outer || outfitSet.top || outfitSet.bottom || outfitSet.shoes;
             if (hasAnyItem) {
               setOutfit(outfitSet);
@@ -70,17 +85,123 @@ const FittingPage = () => {
       }
     };
 
-    fetchRecommendation();
+    fetchData();
   }, [calendarEvent, isToday, navigate]);
+
+  // 피팅하기 버튼 클릭 핸들러
+  const handleFittingClick = () => {
+    if (!userFullBodyImage) {
+      setFittingError('전신 사진이 등록되지 않았습니다. 마이페이지에서 전신 사진을 먼저 등록해주세요.');
+      return;
+    }
+    setShowCreditModal(true);
+  };
+
+  // base64를 Blob으로 변환
+  const base64ToBlob = (base64, mimeType = 'image/jpeg') => {
+    const byteString = atob(base64.split(',')[1]);
+    const ab = new ArrayBuffer(byteString.length);
+    const ia = new Uint8Array(ab);
+    for (let i = 0; i < byteString.length; i++) {
+      ia[i] = byteString.charCodeAt(i);
+    }
+    return new Blob([ab], { type: mimeType });
+  };
+
+  // URL에서 이미지를 Blob으로 가져오기
+  const urlToBlob = async (url) => {
+    const response = await fetch(url);
+    return await response.blob();
+  };
+
+  // 피팅 API 호출
+  const handleConfirmFitting = async () => {
+    setShowCreditModal(false);
+    setIsFitting(true);
+    setFittingError(null);
+
+    try {
+      const token = localStorage.getItem('accessToken');
+      const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000';
+      
+      const formData = new FormData();
+      
+      // 사용자 전신 사진 추가
+      const personBlob = base64ToBlob(userFullBodyImage);
+      formData.append('person', personBlob, 'person.jpg');
+      
+      // 추천된 의류 이미지들 추가
+      if (outfit.outer) {
+        const outerUrl = outfit.outer.image || outfit.outer.imageUrl || outfit.outer.image_url;
+        if (outerUrl.startsWith('data:')) {
+          formData.append('outer', base64ToBlob(outerUrl), 'outer.jpg');
+        } else {
+          const outerBlob = await urlToBlob(outerUrl);
+          formData.append('outer', outerBlob, 'outer.jpg');
+        }
+      }
+      
+      if (outfit.top) {
+        const topUrl = outfit.top.image || outfit.top.imageUrl || outfit.top.image_url;
+        if (topUrl.startsWith('data:')) {
+          formData.append('top', base64ToBlob(topUrl), 'top.jpg');
+        } else {
+          const topBlob = await urlToBlob(topUrl);
+          formData.append('top', topBlob, 'top.jpg');
+        }
+      }
+      
+      if (outfit.bottom) {
+        const bottomUrl = outfit.bottom.image || outfit.bottom.imageUrl || outfit.bottom.image_url;
+        if (bottomUrl.startsWith('data:')) {
+          formData.append('bottom', base64ToBlob(bottomUrl), 'bottom.jpg');
+        } else {
+          const bottomBlob = await urlToBlob(bottomUrl);
+          formData.append('bottom', bottomBlob, 'bottom.jpg');
+        }
+      }
+      
+      if (outfit.shoes) {
+        const shoesUrl = outfit.shoes.image || outfit.shoes.imageUrl || outfit.shoes.image_url;
+        if (shoesUrl.startsWith('data:')) {
+          formData.append('shoes', base64ToBlob(shoesUrl), 'shoes.jpg');
+        } else {
+          const shoesBlob = await urlToBlob(shoesUrl);
+          formData.append('shoes', shoesBlob, 'shoes.jpg');
+        }
+      }
+
+      const response = await fetch(`${backendUrl}/api/fitting/virtual-try-on`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`
+        },
+        body: formData,
+      });
+
+      const data = await response.json();
+
+      if (data.success) {
+        setFittingResult(data);
+      } else {
+        setFittingError(data.message || '가상 피팅에 실패했습니다.');
+      }
+    } catch (err) {
+      console.error('Fitting error:', err);
+      setFittingError('피팅 처리 중 오류가 발생했습니다: ' + err.message);
+    } finally {
+      setIsFitting(false);
+    }
+  };
 
   // 로딩 화면
   if (isLoading) {
     return (
-      <div className="bg-gray-50 dark:bg-gray-900 min-h-screen font-sans flex flex-col items-center justify-center">
+      <div className="bg-cream dark:bg-[#1A1918] min-h-screen font-sans flex flex-col items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-4 border-gold border-t-transparent mx-auto mb-4"></div>
-          <p className="text-gray-800 dark:text-gray-100 font-medium">AI가 코디를 추천하고 있어요...</p>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">"{calendarEvent}" 일정에 맞는 옷을 찾는 중</p>
+          <p className="text-charcoal dark:text-cream font-medium">AI가 코디를 추천하고 있어요...</p>
+          <p className="text-sm text-charcoal-light dark:text-cream-dark mt-2">"{calendarEvent}" 일정에 맞는 옷을 찾는 중</p>
         </div>
       </div>
     );
@@ -89,14 +210,14 @@ const FittingPage = () => {
   // 에러 화면
   if (error) {
     return (
-      <div className="bg-gray-50 dark:bg-gray-900 min-h-screen font-sans flex flex-col items-center justify-center p-4">
+      <div className="bg-cream dark:bg-[#1A1918] min-h-screen font-sans flex flex-col items-center justify-center p-4">
         <div className="text-center">
           <span className="material-symbols-rounded text-5xl text-red-400 mb-4 block">error</span>
-          <p className="text-gray-800 dark:text-gray-100 font-medium mb-2">추천을 불러오지 못했어요</p>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{error}</p>
+          <p className="text-charcoal dark:text-cream font-medium mb-2">추천을 불러오지 못했어요</p>
+          <p className="text-sm text-charcoal-light dark:text-cream-dark mb-4">{error}</p>
           <button
             onClick={() => navigate('/')}
-            className="px-6 py-2 bg-gold text-white rounded-xl font-semibold"
+            className="px-6 py-3 btn-premium rounded-xl font-semibold"
           >
             돌아가기
           </button>
@@ -108,14 +229,16 @@ const FittingPage = () => {
   // 추천 결과 없음
   if (!outfit) {
     return (
-      <div className="bg-gray-50 dark:bg-gray-900 min-h-screen font-sans flex flex-col items-center justify-center p-4">
+      <div className="bg-cream dark:bg-[#1A1918] min-h-screen font-sans flex flex-col items-center justify-center p-4">
         <div className="text-center">
-          <span className="material-symbols-rounded text-5xl text-gray-300 mb-4 block">checkroom</span>
-          <p className="text-gray-800 dark:text-gray-100 font-medium mb-2">추천할 코디가 없어요</p>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">옷장에 옷을 더 등록해보세요</p>
+          <div className="w-20 h-20 rounded-full bg-gold/10 flex items-center justify-center mx-auto mb-4">
+            <span className="material-symbols-rounded text-4xl text-gold">checkroom</span>
+          </div>
+          <p className="text-charcoal dark:text-cream font-medium mb-2">추천할 코디가 없어요</p>
+          <p className="text-sm text-charcoal-light dark:text-cream-dark mb-6">옷장에 옷을 더 등록해보세요</p>
           <button
             onClick={() => navigate('/register')}
-            className="px-6 py-2 bg-gold text-white rounded-xl font-semibold"
+            className="px-6 py-3 btn-premium rounded-xl font-semibold"
           >
             옷 등록하기
           </button>
@@ -161,37 +284,39 @@ const FittingPage = () => {
   ].filter(item => item && item.image);
 
   return (
-    <div className="bg-gray-50 dark:bg-gray-900 min-h-screen font-sans flex flex-col">
+    <div className="bg-cream dark:bg-[#1A1918] min-h-screen font-sans flex flex-col">
       {/* Header */}
-      <div className="px-4 py-3 flex items-center justify-between gap-3 bg-white/80 dark:bg-gray-900/80 backdrop-blur-md sticky top-0 z-40">
+      <div className="px-4 py-3 flex items-center justify-between gap-3 glass-warm border-b border-gold-light/20 sticky top-0 z-40">
         <button 
-          onClick={() => navigate(-1)}
-          className="w-10 h-10 -ml-2 rounded-full flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          onClick={() => fittingResult ? setFittingResult(null) : navigate(-1)}
+          className="w-10 h-10 -ml-2 rounded-full flex items-center justify-center hover:bg-gold-light/20 transition-colors"
         >
-          <span className="material-symbols-rounded text-2xl text-gray-600 dark:text-gray-300">arrow_back</span>
+          <span className="material-symbols-rounded text-2xl text-charcoal dark:text-cream">arrow_back</span>
         </button>
         <div className="text-center">
-          <h1 className="text-lg font-bold text-gray-900 dark:text-white">코디 추천</h1>
-          <p className="text-xs text-gray-500 dark:text-gray-400">"{calendarEvent}"</p>
+          <h1 className="text-lg font-bold text-charcoal dark:text-cream">
+            {fittingResult ? '피팅 결과' : '코디 추천'}
+          </h1>
+          <p className="text-xs text-charcoal-light dark:text-cream-dark">"{calendarEvent}"</p>
         </div>
         <div className="w-10"></div>
       </div>
 
       {/* Context Info */}
-      {context && (
-        <div className="px-4 py-2 bg-gold/10 border-b border-gold/20">
+      {context && !fittingResult && (
+        <div className="px-4 py-3 bg-gradient-to-r from-gold/10 to-gold-light/5 border-b border-gold/20">
           <div className="flex items-center justify-center gap-4 text-sm">
             {context.tpo && (
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1.5 px-3 py-1.5 bg-warm-white dark:bg-charcoal/50 rounded-full border border-gold-light/30">
                 <span className="material-symbols-rounded text-gold text-base">label</span>
-                <span className="text-gray-800 dark:text-gray-100 font-medium">{context.tpo}</span>
+                <span className="text-charcoal dark:text-cream font-medium">{context.tpo}</span>
               </div>
             )}
             {context.weather && (
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1.5 px-3 py-1.5 bg-warm-white dark:bg-charcoal/50 rounded-full border border-gold-light/30">
                 <span className="material-symbols-rounded text-gold text-base">thermostat</span>
-                <span className="text-gray-800 dark:text-gray-100">{context.weather.temp}°C</span>
-                <span className="text-gray-500 dark:text-gray-400">{context.weather.condition}</span>
+                <span className="text-charcoal dark:text-cream font-medium">{context.weather.temp}°C</span>
+                <span className="text-charcoal-light dark:text-cream-dark">{context.weather.condition}</span>
               </div>
             )}
           </div>
@@ -200,41 +325,110 @@ const FittingPage = () => {
 
       {/* Main Content */}
       <main className="flex-1 flex flex-col items-center justify-between py-6 px-4">
-        {/* Outfit Display */}
-        <div className="flex-1 w-full flex items-center justify-center">
-          <div className="w-full h-[420px] relative mx-2">
-            {outfitItems.map((item, index) => (
-              <div 
-                key={index}
-                className={`absolute ${item.position} ${item.size} bg-white dark:bg-gray-800 rounded-2xl shadow-lg dark:shadow-none dark:border dark:border-gray-700 flex items-center justify-center p-3 transform ${item.rotate} transition-all duration-300 hover:scale-105 ${item.zIndex}`}
-              >
-                <img 
-                  alt={item.name} 
-                  className="w-full h-full object-contain rounded-xl" 
-                  src={item.image}
-                />
-                <span className="absolute bottom-1 left-1/2 -translate-x-1/2 text-[10px] bg-black/50 text-white px-2 py-0.5 rounded-full">
-                  {item.name}
-                </span>
-              </div>
-            ))}
+        {/* 피팅 진행 중 */}
+        {isFitting && (
+          <div className="flex-1 flex flex-col items-center justify-center">
+            <div className="animate-spin rounded-full h-16 w-16 border-4 border-gold border-t-transparent mb-6"></div>
+            <p className="text-charcoal dark:text-cream font-medium text-lg">가상 피팅 중...</p>
+            <p className="text-sm text-charcoal-light dark:text-cream-dark mt-2">AI가 옷을 입혀보고 있어요</p>
           </div>
-        </div>
+        )}
 
-        {/* Fitting Button */}
-        <div className="w-full px-4 mt-6 mb-4">
-          <button className="w-full h-14 rounded-2xl bg-gradient-to-r from-orange-300 via-pink-400 to-purple-500 text-white font-bold text-lg shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 active:translate-y-0 transition-all flex items-center justify-center gap-2">
-            <span className="material-symbols-rounded">checkroom</span>
-            피팅하기
-          </button>
-        </div>
+        {/* 피팅 결과 */}
+        {fittingResult && !isFitting && (
+          <div className="flex-1 w-full">
+            <div className="bg-warm-white dark:bg-charcoal rounded-2xl p-4 shadow-lifted border border-gold-light/20">
+              {fittingResult.imageUrl ? (
+                <>
+                  <img
+                    src={fittingResult.imageUrl}
+                    alt="Fitting Result"
+                    className="w-full rounded-xl mb-4"
+                  />
+                  <p className="text-sm text-charcoal-light dark:text-cream-dark text-center">
+                    처리 시간: {fittingResult.processingTime?.total?.toFixed(2) || '-'}초
+                  </p>
+                </>
+              ) : (
+                <>
+                  {fittingResult.note && (
+                    <div className="bg-gold/10 border-l-4 border-gold p-3 rounded-lg mb-4">
+                      <p className="text-sm text-charcoal dark:text-cream">{fittingResult.note}</p>
+                    </div>
+                  )}
+                  <div className="prose dark:prose-invert">
+                    <h3 className="text-lg font-semibold text-charcoal dark:text-cream mb-2">AI 분석 결과</h3>
+                    <p className="text-charcoal-light dark:text-cream-dark whitespace-pre-wrap">
+                      {fittingResult.description}
+                    </p>
+                  </div>
+                  <p className="mt-4 text-sm text-charcoal-light dark:text-cream-dark text-center border-t border-gold-light/20 pt-4">
+                    처리 시간: {fittingResult.processingTime?.total?.toFixed(2) || '-'}초
+                  </p>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* 코디 추천 화면 */}
+        {!isFitting && !fittingResult && (
+          <>
+            {/* Outfit Display */}
+            <div className="flex-1 w-full flex items-center justify-center">
+              <div className="w-full h-[420px] relative mx-2 bg-warm-white/50 dark:bg-charcoal/30 rounded-3xl border border-gold-light/20 shadow-soft">
+                {outfitItems.map((item, index) => (
+                  <div 
+                    key={index}
+                    className={`absolute ${item.position} ${item.size} bg-warm-white dark:bg-charcoal rounded-2xl border-2 border-gold-light/30 dark:border-charcoal-light/30 shadow-lifted flex items-center justify-center p-3 transform ${item.rotate} transition-all duration-300 hover:scale-105 hover:border-gold hover:shadow-xl ${item.zIndex}`}
+                  >
+                    <img 
+                      alt={item.name} 
+                      className="w-full h-full object-contain rounded-xl" 
+                      src={item.image}
+                    />
+                    <span className="absolute bottom-1 left-1/2 -translate-x-1/2 text-[10px] bg-charcoal/70 dark:bg-charcoal text-cream px-2 py-0.5 rounded-full font-medium">
+                      {item.name}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Error Message */}
+            {fittingError && (
+              <div className="w-full mb-4 p-3 bg-red-50 dark:bg-red-900/20 rounded-xl border border-red-200 dark:border-red-800">
+                <p className="text-sm text-red-600 dark:text-red-400 text-center">{fittingError}</p>
+                {!userFullBodyImage && (
+                  <button
+                    onClick={() => navigate('/setup3?edit=true')}
+                    className="mt-2 w-full text-sm text-gold font-medium hover:underline"
+                  >
+                    전신 사진 등록하러 가기 →
+                  </button>
+                )}
+              </div>
+            )}
+
+            {/* Fitting Button */}
+            <div className="w-full px-4 mt-6 mb-4">
+              <button 
+                onClick={handleFittingClick}
+                className="w-full h-14 rounded-2xl btn-premium text-warm-white font-bold text-lg shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 active:translate-y-0 transition-all flex items-center justify-center gap-2"
+              >
+                <span className="material-symbols-rounded">checkroom</span>
+                피팅하기
+              </button>
+            </div>
+          </>
+        )}
       </main>
 
       {/* Bottom Navigation */}
-      <div className="h-20 bg-white/90 dark:bg-gray-800/90 backdrop-blur-md border-t border-gray-200 dark:border-gray-700 flex items-center justify-around pb-2 z-50 safe-area-pb">
+      <div className="h-20 glass-warm border-t border-gold-light/20 flex items-center justify-around pb-2 z-50 safe-area-pb">
         <button 
           onClick={() => navigate('/main')}
-          className="flex flex-col items-center justify-center w-16 h-full text-gray-400 hover:text-primary transition-colors gap-1"
+          className="flex flex-col items-center justify-center w-16 h-full text-charcoal-light dark:text-cream-dark hover:text-gold transition-colors gap-1"
         >
           <span className="material-symbols-rounded text-2xl">home</span>
           <span className="text-[10px] font-medium">홈</span>
@@ -243,17 +437,54 @@ const FittingPage = () => {
         <div className="relative -top-5">
           <button 
             onClick={() => navigate('/register')}
-            className="w-16 h-16 bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-full flex items-center justify-center shadow-lg hover:scale-105 active:scale-95 transition-transform border-4 border-white dark:border-gray-900"
+            className="w-16 h-16 bg-gradient-to-br from-gold to-gold-dark text-warm-white rounded-full flex items-center justify-center shadow-lg hover:scale-105 active:scale-95 transition-transform border-4 border-cream dark:border-[#1A1918]"
           >
             <span className="material-symbols-rounded text-4xl">add</span>
           </button>
         </div>
         
-        <button className="flex flex-col items-center justify-center w-16 h-full text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors gap-1">
+        <button 
+          onClick={() => navigate('/feed')}
+          className="flex flex-col items-center justify-center w-16 h-full text-charcoal-light dark:text-cream-dark hover:text-gold transition-colors gap-1"
+        >
           <span className="material-symbols-rounded text-2xl">grid_view</span>
           <span className="text-[10px] font-medium">SNS</span>
         </button>
       </div>
+
+      {/* 크레딧 확인 모달 */}
+      {showCreditModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-warm-white dark:bg-charcoal rounded-2xl p-6 max-w-sm w-full shadow-xl">
+            <div className="text-center mb-6">
+              <div className="w-16 h-16 rounded-full bg-gold/10 flex items-center justify-center mx-auto mb-4">
+                <span className="material-symbols-rounded text-3xl text-gold">monetization_on</span>
+              </div>
+              <h3 className="text-xl font-bold text-charcoal dark:text-cream mb-2">피팅 크레딧 사용</h3>
+              <p className="text-charcoal-light dark:text-cream-dark">
+                가상 피팅에 <span className="text-gold font-bold">2 크레딧</span>이 사용됩니다.
+              </p>
+              <p className="text-sm text-charcoal-light/70 dark:text-cream-dark/70 mt-2">
+                진행하시겠습니까?
+              </p>
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowCreditModal(false)}
+                className="flex-1 py-3 rounded-xl border border-gold-light/30 text-charcoal dark:text-cream font-medium hover:bg-gold-light/10 transition-colors"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleConfirmFitting}
+                className="flex-1 py-3 rounded-xl btn-premium font-bold"
+              >
+                확인
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/closzIT-front/src/pages/Main/MainPage.jsx
+++ b/closzIT-front/src/pages/Main/MainPage.jsx
@@ -204,6 +204,7 @@ const MainPage = () => {
   };
 
   const isAllSelected = Object.values(selectedOutfit).every(item => item !== null);
+  const hasAnySelected = Object.values(selectedOutfit).some(item => item !== null);
 
   const handleScroll = () => {
     if (!scrollContainerRef.current) return;
@@ -527,53 +528,161 @@ const MainPage = () => {
               </div>
             </div>
 
-            {/* ========== Character Styling Area with Animation ========== */}
+            {/* ========== Selected Outfit Area ========== */}
             <div className="relative mt-4 mb-6 animate-reveal animate-reveal-3">
               <div 
-                className="rounded-3xl p-6 min-h-[220px] flex flex-col items-center justify-center"
+                className="rounded-2xl p-3 flex flex-col"
                 style={{
                   background: 'linear-gradient(180deg, rgba(250, 248, 245, 0.8) 0%, rgba(255, 255, 255, 0.95) 100%)',
                   border: '1px solid rgba(212, 175, 55, 0.15)',
                   boxShadow: '0 4px 20px rgba(0, 0, 0, 0.04)',
                 }}
               >
-                {/* Character Image with Wobble Animation */}
-                <div 
-                  className="w-36 h-36 mb-4 flex items-center justify-center"
-                  style={{
-                    animation: 'float 3s ease-in-out infinite',
-                    transformOrigin: 'center bottom',
-                  }}
-                >
-                  <img 
-                    src="/assets/stylist-character.png" 
-                    alt="AI Stylist Character"
-                    className="w-full h-full object-contain drop-shadow-lg"
-                    style={{
-                      filter: 'drop-shadow(0 4px 8px rgba(0, 0, 0, 0.1))',
-                    }}
-                    onError={(e) => {
-                      e.target.style.display = 'none';
-                      e.target.nextSibling.style.display = 'flex';
-                    }}
-                  />
-                  {/* Fallback Character */}
-                  <div 
-                    className="hidden w-28 h-28 rounded-full items-center justify-center"
-                    style={{
-                      background: 'linear-gradient(135deg, #FFE4B5 0%, #DEB887 100%)',
-                      boxShadow: '0 4px 12px rgba(222, 184, 135, 0.3)',
-                      animation: 'wobble 2s ease-in-out infinite',
-                    }}
-                  >
-                    <span className="material-symbols-rounded text-5xl text-amber-700">face</span>
-                  </div>
-                </div>
-                
-                {/* Styling Message */}
-                <p className="text-center text-charcoal dark:text-cream text-sm font-medium">
-                  어떤 옷을 입어보실래요?
-                </p>
+                {/* 선택된 옷이 하나라도 있으면 러프하게 던져진 의류, 아니면 캐릭터 */}
+                {Object.values(selectedOutfit).some(item => item !== null) ? (
+                  <>
+                    {/* 가로로 펼쳐진 의류 - 카드처럼 */}
+                    <div className="flex justify-center items-end flex-1 py-4 -space-x-4">
+                      {/* 외투 */}
+                      {selectedOutfit.outerwear && (
+                        <div 
+                          className="w-20 cursor-pointer group z-10"
+                          onClick={() => handleDeselectCloth('outerwear')}
+                          style={{ transform: 'rotate(-6deg) translateY(-8px)' }}
+                        >
+                          <div className="relative bg-warm-white dark:bg-charcoal/50 rounded-xl shadow-lifted overflow-hidden border-2 border-gold/30 transition-all group-hover:scale-110 group-hover:shadow-xl group-hover:z-50">
+                            <img 
+                              src={selectedOutfit.outerwear.image || selectedOutfit.outerwear.imageUrl}
+                              alt=""
+                              className="w-full aspect-square object-cover"
+                            />
+                            <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                              <span className="material-symbols-rounded text-white text-lg">close</span>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                      
+                      {/* 상의 */}
+                      {selectedOutfit.tops && (
+                        <div 
+                          className="w-20 cursor-pointer group z-20"
+                          onClick={() => handleDeselectCloth('tops')}
+                          style={{ transform: 'rotate(-2deg) translateY(-4px)' }}
+                        >
+                          <div className="relative bg-warm-white dark:bg-charcoal/50 rounded-xl shadow-lifted overflow-hidden border-2 border-gold/30 transition-all group-hover:scale-110 group-hover:shadow-xl group-hover:z-50">
+                            <img 
+                              src={selectedOutfit.tops.image || selectedOutfit.tops.imageUrl}
+                              alt=""
+                              className="w-full aspect-square object-cover"
+                            />
+                            <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                              <span className="material-symbols-rounded text-white text-lg">close</span>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                      
+                      {/* 하의 */}
+                      {selectedOutfit.bottoms && (
+                        <div 
+                          className="w-20 cursor-pointer group z-30"
+                          onClick={() => handleDeselectCloth('bottoms')}
+                          style={{ transform: 'rotate(3deg) translateY(-6px)' }}
+                        >
+                          <div className="relative bg-warm-white dark:bg-charcoal/50 rounded-xl shadow-lifted overflow-hidden border-2 border-gold/30 transition-all group-hover:scale-110 group-hover:shadow-xl group-hover:z-50">
+                            <img 
+                              src={selectedOutfit.bottoms.image || selectedOutfit.bottoms.imageUrl}
+                              alt=""
+                              className="w-full aspect-square object-cover"
+                            />
+                            <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                              <span className="material-symbols-rounded text-white text-lg">close</span>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                      
+                      {/* 신발 */}
+                      {selectedOutfit.shoes && (
+                        <div 
+                          className="w-20 cursor-pointer group z-40"
+                          onClick={() => handleDeselectCloth('shoes')}
+                          style={{ transform: 'rotate(7deg) translateY(-10px)' }}
+                        >
+                          <div className="relative bg-warm-white dark:bg-charcoal/50 rounded-xl shadow-lifted overflow-hidden border-2 border-gold/30 transition-all group-hover:scale-110 group-hover:shadow-xl group-hover:z-50">
+                            <img 
+                              src={selectedOutfit.shoes.image || selectedOutfit.shoes.imageUrl}
+                              alt=""
+                              className="w-full aspect-square object-cover"
+                            />
+                            <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                              <span className="material-symbols-rounded text-white text-lg">close</span>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                    
+                    {/* 피팅하기 버튼 - 모두 선택했을 때만 표시 */}
+                    {hasAnySelected && (
+                      <button
+                        onClick={() => {
+                          navigate('/fitting/direct', { 
+                            state: { 
+                              outfit: selectedOutfit,
+                              fromMain: true 
+                            } 
+                          });
+                        }}
+                        className="mt-3 w-full py-3.5 rounded-xl btn-premium font-bold text-sm flex items-center justify-center gap-2 shadow-lg hover:shadow-xl transition-all animate-fadeIn"
+                      >
+                        <span className="material-symbols-rounded text-lg">checkroom</span>
+                        피팅해보기
+                      </button>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    {/* 캐릭터 이미지 - 아무것도 선택 안했을 때 */}
+                    <div className="flex-1 flex flex-col items-center justify-center">
+                      <div 
+                        className="w-28 h-28 mb-3 flex items-center justify-center"
+                        style={{
+                          animation: 'float 3s ease-in-out infinite',
+                          transformOrigin: 'center bottom',
+                        }}
+                      >
+                        <img 
+                          src="/assets/stylist-character.png" 
+                          alt="AI Stylist Character"
+                          className="w-full h-full object-contain drop-shadow-lg"
+                          style={{
+                            filter: 'drop-shadow(0 4px 8px rgba(0, 0, 0, 0.1))',
+                          }}
+                          onError={(e) => {
+                            e.target.style.display = 'none';
+                            e.target.nextSibling.style.display = 'flex';
+                          }}
+                        />
+                        {/* Fallback Character */}
+                        <div 
+                          className="hidden w-24 h-24 rounded-full items-center justify-center"
+                          style={{
+                            background: 'linear-gradient(135deg, #FFE4B5 0%, #DEB887 100%)',
+                            boxShadow: '0 4px 12px rgba(222, 184, 135, 0.3)',
+                            animation: 'wobble 2s ease-in-out infinite',
+                          }}
+                        >
+                          <span className="material-symbols-rounded text-4xl text-amber-700">face</span>
+                        </div>
+                      </div>
+                      <p className="text-center text-charcoal dark:text-cream text-sm font-medium">
+                        오늘 입고 싶은 옷을 골라보세요 ✨
+                      </p>
+                    </div>
+                  </>
+                )}
               </div>
             </div>
 

--- a/closzIT-front/src/pages/MyPage/MyPage.jsx
+++ b/closzIT-front/src/pages/MyPage/MyPage.jsx
@@ -160,6 +160,37 @@ const MyPage = () => {
                 </div>
               </div>
             )}
+            
+            {/* 전신 사진 섹션 */}
+            <div className="py-4 border-t border-gold-light/30 mt-2">
+              <span className="text-charcoal-light dark:text-cream-dark block mb-3">전신 사진</span>
+              {user?.fullBodyImage ? (
+                <div className="flex items-center gap-4">
+                  <div className="w-24 h-32 rounded-xl overflow-hidden border-2 border-gold-light/30 bg-charcoal/5 dark:bg-charcoal/30">
+                    <img 
+                      src={user.fullBodyImage} 
+                      alt="전신 사진" 
+                      className="w-full h-full object-contain"
+                    />
+                  </div>
+                  <button
+                    onClick={() => navigate('/setup3?edit=true')}
+                    className="flex items-center gap-2 px-4 py-2 bg-gold/10 text-gold rounded-xl text-sm font-medium border border-gold/20 hover:bg-gold/20 transition-colors"
+                  >
+                    <span className="material-symbols-rounded text-base">edit</span>
+                    사진 변경
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => navigate('/setup3?edit=true')}
+                  className="flex items-center justify-center gap-2 w-full py-4 bg-gold/10 text-gold rounded-xl text-sm font-medium border border-dashed border-gold/30 hover:bg-gold/20 transition-colors"
+                >
+                  <span className="material-symbols-rounded text-lg">add_a_photo</span>
+                  전신 사진 등록하기
+                </button>
+              )}
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## 변경 사항
- **Partial Virtual Fitting (부분 가상 피팅) 구현**
  - 의류(외투, 상의, 하의, 신발) 중 1개 이상만 선택해도 피팅이 가능하도록 개선
  - 백엔드: `/api/fitting/partial-try-on` 엔드포인트 및 `processPartialFitting` 서비스 메서드 추가
  - 프론트엔드: `DirectFittingPage`에서 상황에 따라 API 호출 분기 처리
- **MainPage UI 개선**
  - 선택된 의류를 카드 형태로 자연스럽게 펼쳐서 배치 (2x2 그리드 대신)
  - "피팅해보기" 버튼 노출 조건 완화 (전체 선택 -> 1개 이상 선택)

## 상세 내용
- `MainPage.jsx`: 의류 배치 스타일 변경 (회전 및 오버랩 효과), 문구 수정 ("오늘 입고 싶은 ~~")
- `fitting.service.ts`: `VTO_USED` 크레딧 타입 사용하여 부분 피팅 로직 구현 (DB 스키마 변경 없음)

## 체크리스트
- [x] 부분 피팅 API 동작 확인
- [x] 메인 페이지 UI 변경 확인
- [x] DB 스키마 무결성 유지 (기존 enum 사용)
