### PR TITLE
refactor(ui): SNS 이미지 스타일 개선 및 VTO 버튼 상태 분리

### DIFF
--- a/closzIT-front/src/pages/FeedPage.jsx
+++ b/closzIT-front/src/pages/FeedPage.jsx
@@ -150,7 +150,7 @@ const FeedPage = () => {
                   <img
                     src={post.imageUrl}
                     alt="Post"
-                    className="w-full h-full object-cover"
+                    className="w-full h-full object-contain"
                   />
                 </div>
 

--- a/closzIT-front/src/pages/Fitting/FittingPage.jsx
+++ b/closzIT-front/src/pages/Fitting/FittingPage.jsx
@@ -6,7 +6,8 @@ import { useVto } from '../../context/VtoContext';
 const FittingPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { requestPartialVto, isPartialVtoLoading } = useVto();
+  const { requestPartialVto, checkPartialVtoLoading } = useVto();
+  const isPartialVtoLoading = checkPartialVtoLoading('fitting');
   const { calendarEvent, isToday } = location.state || {};
 
   const [outfit, setOutfit] = useState(null);
@@ -150,7 +151,7 @@ const FittingPage = () => {
       await processImage(outfit.shoes, 'shoes');
 
       // VtoContext의 requestPartialVto 호출 (크레딧 모달 표시 → 확인 시 백그라운드 실행)
-      requestPartialVto(formData, buttonPosition);
+      requestPartialVto(formData, buttonPosition, 'fitting');
 
     } catch (err) {
       console.error('Fitting setup error:', err);
@@ -317,8 +318,8 @@ const FittingPage = () => {
             }}
             disabled={isPartialVtoLoading}
             className={`w-full h-14 rounded-2xl font-bold text-lg shadow-lg transition-all flex items-center justify-center gap-2 ${isPartialVtoLoading
-                ? 'bg-gold-light/50 text-charcoal cursor-wait'
-                : 'btn-premium text-warm-white hover:shadow-xl transform hover:-translate-y-0.5 active:translate-y-0'
+              ? 'bg-gold-light/50 text-charcoal cursor-wait'
+              : 'btn-premium text-warm-white hover:shadow-xl transform hover:-translate-y-0.5 active:translate-y-0'
               }`}
           >
             {isPartialVtoLoading ? (

--- a/closzIT-front/src/pages/Main/MainPage.jsx
+++ b/closzIT-front/src/pages/Main/MainPage.jsx
@@ -14,7 +14,8 @@ const categories = [
 
 const MainPage = () => {
   const navigate = useNavigate();
-  const { requestPartialVto, isPartialVtoLoading } = useVto();
+  const { requestPartialVto, checkPartialVtoLoading } = useVto();
+  const isPartialVtoLoading = checkPartialVtoLoading('main');
 
   const [activeCategory, setActiveCategory] = useState('outerwear');
   const [currentClothIndex, setCurrentClothIndex] = useState(0);
@@ -162,7 +163,7 @@ const MainPage = () => {
       await processImage(selectedOutfit.shoes, 'shoes');
 
       // VtoContext의 requestPartialVto 호출 (크레딧 모달 + 애니메이션)
-      requestPartialVto(formData, buttonPosition);
+      requestPartialVto(formData, buttonPosition, 'main');
 
     } catch (err) {
       console.error('Fitting setup error:', err);
@@ -695,8 +696,8 @@ const MainPage = () => {
                         }}
                         disabled={isPartialVtoLoading}
                         className={`mt-3 w-full py-3.5 rounded-xl font-bold text-sm flex items-center justify-center gap-2 shadow-lg transition-all animate-fadeIn ${isPartialVtoLoading
-                            ? 'bg-gold-light/50 text-charcoal cursor-wait'
-                            : 'btn-premium hover:shadow-xl'
+                          ? 'bg-gold-light/50 text-charcoal cursor-wait'
+                          : 'btn-premium hover:shadow-xl'
                           }`}
                       >
                         {isPartialVtoLoading ? (

--- a/closzIT-front/src/pages/PostDetailPage.jsx
+++ b/closzIT-front/src/pages/PostDetailPage.jsx
@@ -214,7 +214,7 @@ const PostDetailPage = () => {
           <img
             src={post.imageUrl}
             alt="Post"
-            className="w-full h-full object-cover"
+            className="w-full h-full object-contain"
           />
         </div>
 
@@ -266,10 +266,10 @@ const PostDetailPage = () => {
                 onClick={handleTryOn}
                 disabled={tryOnLoading || tryOnCompleted}
                 className={`mt-4 w-full py-3 rounded-xl font-semibold flex items-center justify-center gap-2 transition-all ${tryOnCompleted
-                    ? 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400 cursor-not-allowed'
-                    : tryOnLoading
-                      ? 'bg-gold-light/50 text-charcoal cursor-wait'
-                      : 'btn-premium hover:scale-[1.02]'
+                  ? 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400 cursor-not-allowed'
+                  : tryOnLoading
+                    ? 'bg-gold-light/50 text-charcoal cursor-wait'
+                    : 'btn-premium hover:scale-[1.02]'
                   }`}
               >
                 {tryOnLoading ? (


### PR DESCRIPTION
## 개요

SNS 이미지 스타일 개선 및 VTO 버튼 상태 분리 작업을 수행했습니다.

## 변경 사항

### UI 개선
- **SNS 피드 및 상세 페이지**: 메인 이미지 스타일을 `object-cover`에서 `object-contain`으로 변경하여 이미지가 잘리지 않고 온전하게 표시되도록 수정했습니다.

### 로직 개선 (VTO 버튼 상태 분리)
- **VtoContext**: `isPartialVtoLoading` (단일 boolean) 상태를 `partialVtoLoadingSources` (Set)으로 변경하여 요청 소스별로 로딩 상태를 추적하도록 개선했습니다.
- **MainPage**: 메인 페이지의 '입어보기' 버튼은 이제 메인 페이지에서 발생한 요청에 대해서만 로딩 상태를 표시합니다.
- **FittingPage**: 추천(피팅) 페이지의 '입어보기' 버튼은 해당 페이지에서 발생한 요청에 대해서만 로딩 상태를 표시합니다.
- 이를 통해 한 페이지에서의 VTO 요청이 다른 페이지의 UI에 영향을 주지 않도록 수정했습니다.

## 수정된 파일

- `closzIT-front/src/pages/FeedPage.jsx`
- `closzIT-front/src/pages/PostDetailPage.jsx`
- `closzIT-front/src/context/VtoContext.jsx`
- `closzIT-front/src/pages/Main/MainPage.jsx`
- `closzIT-front/src/pages/Fitting/FittingPage.jsx`

## 테스트 체크리스트

- [ ] SNS 피드 이미지가 잘리지 않고 전체가 표시되는지 확인
- [ ] 메인 페이지에서 VTO 요청 시, 메인 페이지 버튼만 로딩 표시되는지 확인
- [ ] 메인 페이지 요청 중 추천 페이지로 이동 시, 추천 페이지 버튼은 정상(입어보기) 상태인지 확인
- [ ] 추천 페이지에서 VTO 요청 시 정상 동작 및 로딩 표시 확인
