### PR TITLE
fix: 브라우저 캐시 문제 해결 - index.html 캐시 방지 헤더 추가

### DIFF
--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -43,6 +43,13 @@ jobs:
         run: |
           aws s3 sync ./closzIT-front/build s3://closzit-frontend --delete
       
+      - name: Set Cache Headers for index.html
+        run: |
+          aws s3 cp s3://closzit-frontend/index.html s3://closzit-frontend/index.html \
+            --metadata-directive REPLACE \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --content-type "text/html"
+      
       - name: CloudFront Invalidation
         run: |
           aws cloudfront create-invalidation \


### PR DESCRIPTION
## 📌 개요
배포 후 브라우저 캐시로 인해 사용자가 새 버전을 보려면 캐시를 지워야 하는 문제 해결

## 🔧 변경 사항

### `.github/workflows/deploy-front.yml`
- S3 업로드 후 `index.html`에 캐시 방지 헤더 추가
- `Cache-Control: no-cache, no-store, must-revalidate` 설정

## 💡 해결 원리
- `index.html`만 캐시 방지 → 브라우저가 항상 새 index.html 받음
- JS/CSS는 파일명에 해시가 있어 캐시 유지 (빠른 로딩)
- 배포 시 새 index.html이 새 JS/CSS 참조 → 자동으로 새 버전 반영

## ✅ 테스트
- [ ] dev 브랜치에 머지 후 배포 확인
- [ ] 캐시 지우지 않고 새 버전 반영되는지 확인
