### PR TITLE
feat: 메인 페이지 UI 개편 및 자연어 검색 기능 추가

### DIFF
--- a/closzIT-front/src/App.js
+++ b/closzIT-front/src/App.js
@@ -35,8 +35,8 @@ function App() {
           <Route path="/setup2" element={<UserProfileSetup2 />} />
           <Route path="/setup3" element={<UserProfileSetup3 />} />
           <Route path="/setup/profile3" element={<UserProfileSetup3 />} />
-          <Route path="/main" element={<MainPage />} />
-          <Route path="/main2" element={<MainPage2 />} />
+          <Route path="/main" element={<MainPage2 />} />
+          <Route path="/main2" element={<MainPage />} />
           <Route path="/mypage" element={<MyPage />} />
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/labeling" element={<LabelingPage />} />

--- a/closzIT-front/src/pages/Fitting/FittingPage.jsx
+++ b/closzIT-front/src/pages/Fitting/FittingPage.jsx
@@ -1,5 +1,3 @@
-// src/pages/fitting/FittingPage.jsx
-
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import SharedHeader from '../../components/SharedHeader';
@@ -10,23 +8,25 @@ const FittingPage = () => {
   const location = useLocation();
   const { requestPartialVtoByIds, checkPartialVtoLoading } = useVto();
   const isPartialVtoLoading = checkPartialVtoLoading('fitting');
-  const { calendarEvent, isToday } = location.state || {};
+  const { calendarEvent, isToday, userQuery, keywords } = location.state || {};
 
-  const [outfits, setOutfits] = useState([]);
-  const [candidates, setCandidates] = useState(null);
-  const [meta, setMeta] = useState(null);
-  const [currentOutfitIndex, setCurrentOutfitIndex] = useState(0);
+  const [outfits, setOutfits] = useState([]);         // 상위 5개 조합
+  const [candidates, setCandidates] = useState(null); // 카테고리별 후보
+  const [meta, setMeta] = useState(null);             // 검색 메타 정보
+  const [currentOutfitIndex, setCurrentOutfitIndex] = useState(0); // 현재 선택된 조합
   const [context, setContext] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
   const [fittingError, setFittingError] = useState(null);
   const [userFullBodyImage, setUserFullBodyImage] = useState(null);
-  const [isFeedbackLoading, setIsFeedbackLoading] = useState(false);
 
+  // 현재 선택된 outfit
   const currentOutfit = outfits[currentOutfitIndex] || null;
 
+  // API에서 추천 받아오기 + 사용자 전신 사진 가져오기
   useEffect(() => {
-    if (!calendarEvent) {
+    // calendarEvent 또는 userQuery 또는 keywords 중 하나라도 있어야 함
+    if (!calendarEvent && !userQuery && (!keywords || keywords.length === 0)) {
       navigate('/');
       return;
     }
@@ -41,6 +41,7 @@ const FittingPage = () => {
 
         const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000';
 
+        // 사용자 정보 가져오기 (전신 사진 포함)
         const userResponse = await fetch(`${backendUrl}/user/me`, {
           headers: { 'Authorization': `Bearer ${token}` }
         });
@@ -50,6 +51,7 @@ const FittingPage = () => {
           setUserFullBodyImage(userData.fullBodyImage);
         }
 
+        // 코디 추천 받기
         const response = await fetch(`${backendUrl}/recommendation/search`, {
           method: 'POST',
           headers: {
@@ -58,7 +60,10 @@ const FittingPage = () => {
           },
           body: JSON.stringify({
             calendarEvent,
+            calendarEvent,
             isToday,
+            query: userQuery,
+            keywords,
           }),
         });
 
@@ -93,6 +98,7 @@ const FittingPage = () => {
     fetchData();
   }, [calendarEvent, isToday, navigate]);
 
+  // base64를 Blob으로 변환
   const base64ToBlob = (base64, mimeType = 'image/jpeg') => {
     const byteString = atob(base64.split(',')[1]);
     const ab = new ArrayBuffer(byteString.length);
@@ -103,11 +109,13 @@ const FittingPage = () => {
     return new Blob([ab], { type: mimeType });
   };
 
+  // URL에서 이미지를 Blob으로 가져오기
   const urlToBlob = async (url) => {
     const response = await fetch(url);
     return await response.blob();
   };
 
+  // 이미지 URL 가져오기 헬퍼 (flatten_image_url 우선)
   const getImageUrl = (item) => {
     if (!item) return null;
     // flatten_image_url이 있으면 우선 사용
@@ -115,18 +123,21 @@ const FittingPage = () => {
       || item.image_url || item.imageUrl || item.image;
   };
 
+  // 이전 조합으로 이동
   const handlePrevOutfit = () => {
     setCurrentOutfitIndex((prev) =>
       prev === 0 ? outfits.length - 1 : prev - 1
     );
   };
 
+  // 다음 조합으로 이동
   const handleNextOutfit = () => {
     setCurrentOutfitIndex((prev) =>
       prev === outfits.length - 1 ? 0 : prev + 1
     );
   };
 
+  // 피팅하기 버튼 클릭
   const handleFittingClick = async (event) => {
     let buttonPosition = null;
     if (event?.currentTarget) {
@@ -170,49 +181,39 @@ const FittingPage = () => {
     }
   };
 
+  // 피드백 전송
   const handleFeedback = async (feedbackType) => {
-    if (!currentOutfit || isFeedbackLoading) return;
-
-    setIsFeedbackLoading(true);
-
-    const feedbackTypeMap = {
-      'accept': 'ACCEPT',
-      'reject': 'REJECT',
-      'worn': 'WORN',
-    };
+    if (!currentOutfit) return;
 
     try {
       const token = localStorage.getItem('accessToken');
       const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000';
 
-      const response = await fetch(`${backendUrl}/recommendation/feedback`, {
+      await fetch(`${backendUrl}/recommendation/feedback`, {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json',
-          'Idempotency-Key': crypto.randomUUID(),
         },
         body: JSON.stringify({
           outer_id: currentOutfit.outer?.id,
           top_id: currentOutfit.top?.id,
           bottom_id: currentOutfit.bottom?.id,
           shoes_id: currentOutfit.shoes?.id,
-          feedback_type: feedbackTypeMap[feedbackType],
+          feedback_type: feedbackType,
         }),
       });
 
-      const result = await response.json();
-
-      if (result.duplicate) {
-        console.log('이미 처리된 피드백:', result.message);
+      // 거절 시 다음 조합으로 이동
+      if (feedbackType === 'reject' && outfits.length > 1) {
+        handleNextOutfit();
       }
     } catch (err) {
       console.error('Feedback error:', err);
-    } finally {
-      setIsFeedbackLoading(false);
     }
   };
 
+  // 로딩 화면
   if (isLoading) {
     return (
       <div className="bg-cream dark:bg-[#1A1918] min-h-screen font-sans flex flex-col items-center justify-center">
@@ -225,6 +226,7 @@ const FittingPage = () => {
     );
   }
 
+  // 에러 화면
   if (error) {
     return (
       <div className="bg-cream dark:bg-[#1A1918] min-h-screen font-sans flex flex-col items-center justify-center p-4">
@@ -243,6 +245,7 @@ const FittingPage = () => {
     );
   }
 
+  // 추천 결과 없음
   if (outfits.length === 0) {
     return (
       <div className="bg-cream dark:bg-[#1A1918] min-h-screen font-sans flex flex-col items-center justify-center p-4">
@@ -267,6 +270,7 @@ const FittingPage = () => {
             </div>
           )}
 
+          {/* 카테고리별 후보 개수 */}
           {meta?.totalCandidates && (
             <div className="mb-4 p-3 bg-warm-white dark:bg-charcoal/50 rounded-xl">
               <p className="text-xs text-charcoal-light dark:text-cream-dark mb-2">카테고리별 후보</p>
@@ -305,6 +309,7 @@ const FittingPage = () => {
     );
   }
 
+  // 추천된 아이템들을 표시용 배열로 변환
   const outfitItems = [
     currentOutfit?.outer && {
       name: '외투',
@@ -346,12 +351,14 @@ const FittingPage = () => {
 
   return (
     <div className="bg-cream dark:bg-[#1A1918] min-h-screen font-sans flex flex-col">
+      {/* Shared Header */}
       <SharedHeader
         title="코디 추천"
         showBackButton
         onBackClick={() => navigate(-1)}
       />
 
+      {/* Context Info */}
       {context && (
         <div className="px-4 py-3 bg-gradient-to-r from-gold/10 to-gold-light/5 border-b border-gold/20">
           <div className="flex items-center justify-center gap-4 text-sm">
@@ -372,7 +379,9 @@ const FittingPage = () => {
         </div>
       )}
 
+      {/* Main Content */}
       <main className="flex-1 flex flex-col items-center justify-between py-4 px-4">
+        {/* 조합 선택 인디케이터 */}
         {outfits.length > 1 && (
           <div className="w-full flex items-center justify-between mb-3">
             <button
@@ -404,6 +413,7 @@ const FittingPage = () => {
           </div>
         )}
 
+        {/* 조합 점수 표시 */}
         {currentOutfit?.displayScore && (
           <div className="mb-2 px-4 py-1.5 bg-gold/10 rounded-full">
             <span className="text-xs text-charcoal dark:text-cream">
@@ -412,6 +422,7 @@ const FittingPage = () => {
           </div>
         )}
 
+        {/* Outfit Display */}
         <div className="flex-1 w-full flex items-center justify-center">
           <div className="w-full h-[380px] relative mx-2 bg-warm-white/50 dark:bg-charcoal/30 rounded-3xl border border-gold-light/20 shadow-soft">
             {outfitItems.map((item, index) => (
@@ -432,57 +443,46 @@ const FittingPage = () => {
           </div>
         </div>
 
+        {/* Error Message */}
         {fittingError && (
           <div className="w-full mb-3 p-3 bg-red-50 dark:bg-red-900/20 rounded-xl border border-red-200 dark:border-red-800">
             <p className="text-sm text-red-600 dark:text-red-400 text-center">{fittingError}</p>
           </div>
         )}
 
+        {/* Action Buttons */}
         <div className="w-full space-y-3 mt-4 mb-4">
+          {/* 피드백 버튼 */}
           <div className="flex gap-3">
             <button
               onClick={() => handleFeedback('reject')}
-              disabled={isFeedbackLoading}
-              className={`flex-1 h-12 rounded-xl font-medium border-2 border-red-300 dark:border-red-700 text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors flex items-center justify-center gap-2 ${
-                isFeedbackLoading ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
+              className="flex-1 h-12 rounded-xl font-medium border-2 border-red-300 dark:border-red-700 text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors flex items-center justify-center gap-2"
             >
-              {isFeedbackLoading ? (
-                <span className="material-symbols-rounded text-xl animate-spin">progress_activity</span>
-              ) : (
-                <span className="material-symbols-rounded text-xl">thumb_down</span>
-              )}
-              싫어요
+              <span className="material-symbols-rounded text-xl">thumb_down</span>
+              다른 코디
             </button>
             <button
               onClick={() => handleFeedback('accept')}
-              disabled={isFeedbackLoading}
-              className={`flex-1 h-12 rounded-xl font-medium border-2 border-green-300 dark:border-green-700 text-green-500 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20 transition-colors flex items-center justify-center gap-2 ${
-                isFeedbackLoading ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
+              className="flex-1 h-12 rounded-xl font-medium border-2 border-green-300 dark:border-green-700 text-green-500 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20 transition-colors flex items-center justify-center gap-2"
             >
-              {isFeedbackLoading ? (
-                <span className="material-symbols-rounded text-xl animate-spin">progress_activity</span>
-              ) : (
-                <span className="material-symbols-rounded text-xl">thumb_up</span>
-              )}
-              좋아요
+              <span className="material-symbols-rounded text-xl">thumb_up</span>
+              마음에 들어요
             </button>
           </div>
 
+          {/* 피팅 버튼 */}
           <button
             onClick={(e) => {
-              if (!isPartialVtoLoading && !isFeedbackLoading) {
-                handleFeedback('accept');
+              if (!isPartialVtoLoading) {
+                handleFeedback('accept'); // 피팅 시 자동으로 accept
                 handleFittingClick(e);
               }
             }}
-            disabled={isPartialVtoLoading || isFeedbackLoading}
-            className={`w-full h-14 rounded-2xl font-bold text-lg shadow-lg transition-all flex items-center justify-center gap-2 ${
-              isPartialVtoLoading || isFeedbackLoading
-                ? 'bg-gold-light/50 text-charcoal cursor-wait'
-                : 'btn-premium text-warm-white hover:shadow-xl transform hover:-translate-y-0.5 active:translate-y-0'
-            }`}
+            disabled={isPartialVtoLoading}
+            className={`w-full h-14 rounded-2xl font-bold text-lg shadow-lg transition-all flex items-center justify-center gap-2 ${isPartialVtoLoading
+              ? 'bg-gold-light/50 text-charcoal cursor-wait'
+              : 'btn-premium text-warm-white hover:shadow-xl transform hover:-translate-y-0.5 active:translate-y-0'
+              }`}
           >
             {isPartialVtoLoading ? (
               <>
@@ -499,6 +499,7 @@ const FittingPage = () => {
         </div>
       </main>
 
+      {/* Bottom Navigation */}
       <div className="h-20 glass-warm border-t border-gold-light/20 flex items-center justify-around pb-2 z-50 safe-area-pb">
         <button
           onClick={() => navigate('/main')}

--- a/closzIT-front/src/pages/Main/MainPage.jsx
+++ b/closzIT-front/src/pages/Main/MainPage.jsx
@@ -23,7 +23,6 @@ const MainPage = () => {
   const [userName, setUserName] = useState('');
   const [userCredit, setUserCredit] = useState(0);
   const [userFullBodyImage, setUserFullBodyImage] = useState(null);
-  const [vtoResultImage, setVtoResultImage] = useState(null); // VTO 결과 이미지
   const [userClothes, setUserClothes] = useState({
     outerwear: [],
     tops: [],
@@ -878,69 +877,8 @@ const MainPage = () => {
               )}
             </div>
 
-            {/* Modal Footer - 하나만 입어보기 / 수정/삭제 버튼 */}
+            {/* Modal Footer - 수정/삭제 버튼 */}
             <div className="p-4 border-t border-gold-light/20 space-y-2">
-              {/* 하나만 입어보기 버튼 (IDM-VTON) */}
-              <button
-                onClick={async () => {
-                  if (!userFullBodyImage) {
-                    const confirm = window.confirm(
-                      '피팅 모델 이미지가 없어서 착장서비스 이용이 불가합니다. 등록하시겠습니까?'
-                    );
-                    if (confirm) {
-                      navigate('/setup3?edit=true');
-                    }
-                    return;
-                  }
-
-                  try {
-                    setSelectedClothDetail(null); // 모달 닫기
-
-                    const token = localStorage.getItem('accessToken');
-                    const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000';
-
-                    // 로딩 표시
-                    alert('단일 옷 가상 피팅을 생성 중입니다... (약 4-5초 소요)');
-
-                    const response = await fetch(`${backendUrl}/api/fitting/single-item-tryon`, {
-                      method: 'POST',
-                      headers: {
-                        'Authorization': `Bearer ${token}`,
-                        'Content-Type': 'application/json',
-                      },
-                      body: JSON.stringify({
-                        clothingId: selectedClothDetail.id,
-                        denoiseSteps: 20,
-                        seed: Math.floor(Math.random() * 1000000),
-                      }),
-                    });
-
-                    if (!response.ok) {
-                      const errorData = await response.json();
-                      throw new Error(errorData.message || '가상 피팅 실패');
-                    }
-
-                    const result = await response.json();
-
-                    // 결과 이미지 표시 (모달로)
-                    if (result.success && result.imageUrl) {
-                      // 팝업 차단 문제 방지: 모달로 표시
-                      setSelectedClothDetail(null); // 기존 모달 닫기
-                      setVtoResultImage(result.imageUrl); // 결과 이미지 표시
-                    } else {
-                      throw new Error('결과 이미지를 받지 못했습니다.');
-                    }
-                  } catch (error) {
-                    console.error('Single item try-on error:', error);
-                    alert(`가상 피팅 실패: ${error.message}`);
-                  }
-                }}
-                className="w-full py-3.5 bg-gradient-to-r from-purple-500 to-indigo-500 text-white rounded-xl font-bold hover:from-purple-600 hover:to-indigo-600 transition-all shadow-lg hover:shadow-xl flex items-center justify-center gap-2"
-              >
-                <span className="material-symbols-rounded text-lg">auto_awesome</span>
-                하나만 입어보기 (AI)
-              </button>
-
               <div className="flex gap-2">
                 <button
                   onClick={() => {
@@ -990,57 +928,6 @@ const MainPage = () => {
               >
                 닫기
               </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* VTO 결과 모달 */}
-      {vtoResultImage && (
-        <div
-          className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-[60] p-4"
-          onClick={() => setVtoResultImage(null)}
-        >
-          <div
-            className="bg-warm-white dark:bg-charcoal rounded-2xl max-w-2xl w-full max-h-[90vh] overflow-auto shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-xl font-bold text-charcoal dark:text-cream flex items-center gap-2">
-                  <span className="material-symbols-rounded text-2xl text-gold">auto_awesome</span>
-                  가상 피팅 결과
-                </h2>
-                <button
-                  onClick={() => setVtoResultImage(null)}
-                  className="p-2 hover:bg-charcoal/10 dark:hover:bg-cream/10 rounded-lg transition-colors"
-                >
-                  <span className="material-symbols-rounded text-charcoal dark:text-cream">close</span>
-                </button>
-              </div>
-
-              <img
-                src={vtoResultImage}
-                alt="Virtual Try-On Result"
-                className="w-full rounded-xl shadow-lg"
-              />
-
-              <div className="mt-4 flex gap-2">
-                <a
-                  href={vtoResultImage}
-                  download="virtual-tryon-result.png"
-                  className="flex-1 py-3 bg-gold text-charcoal rounded-xl font-semibold hover:bg-gold-dark transition-colors flex items-center justify-center gap-2"
-                >
-                  <span className="material-symbols-rounded text-lg">download</span>
-                  다운로드
-                </a>
-                <button
-                  onClick={() => setVtoResultImage(null)}
-                  className="flex-1 py-3 bg-charcoal/10 dark:bg-cream/10 text-charcoal dark:text-cream rounded-xl font-semibold hover:bg-charcoal/20 dark:hover:bg-cream/20 transition-colors"
-                >
-                  닫기
-                </button>
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 변경 사항
- **MainPage2를 기본 메인 페이지로 변경**: `/main` 라우트가 새로운 디자인인 `MainPage2`를 가리키고, 기존 페이지는 `/main2`로 이동되었습니다.
- **옷 상세정보 모달 추가**: 옷 리스트에서 (i) 버튼 클릭 시 상세 정보 모달이 뜨도록 기능을 이식했습니다.
- **자연어 검색 기능**: 검색바에 문장형 입력이 가능하도록 `searchText` 상태를 추가하고, `OutfitRecommender` 및 `FittingPage`와 연동했습니다.
- **캘린더 연동**: `OutfitRecommender`에서 다가오는 일정을 불러오고 선택할 수 있습니다.

## 스크린샷
(스크린샷은 PR 생성 후 첨부 예정)

## Merge Checklist
- [x] 기능 테스트 완료
- [x] 빌드 테스트 완료
