### PR TITLE
fix(vto): VTO 큐잉 result null 에러 수정

### DIFF
--- a/closzIT-back/src/fitting/fitting.controller.ts
+++ b/closzIT-back/src/fitting/fitting.controller.ts
@@ -217,6 +217,9 @@ export class FittingController {
         personImageUrl: user.fullBodyImage,
         clothingUrls,
         type: 'partial-try-on-by-ids',
+      }, {
+        removeOnComplete: { age: 300, count: 100 },
+        removeOnFail: { age: 3600 },
       });
 
       this.logger.log(`[VTO Queue] Job ${job.id} queued for user ${userId}`);
@@ -379,6 +382,9 @@ export class FittingController {
         postId: body.postId,
         clothingId: body.clothingId,
         clothingOwnerId, // 옷 주인 ID (캐시용)
+      }, {
+        removeOnComplete: { age: 300, count: 100 },
+        removeOnFail: { age: 3600 },
       });
 
       this.logger.log(`[VTO Queue] Job ${job.id} queued for user ${userId}`);
@@ -483,6 +489,9 @@ export class FittingController {
         clothingUrls,
         type: 'sns-full-try-on',
         postId: body.postId,
+      }, {
+        removeOnComplete: { age: 300, count: 100 }, // 5분간 또는 100개까지 보존
+        removeOnFail: { age: 3600 }, // 실패는 1시간 보존
       });
 
       this.logger.log(`[VTO Queue] Job ${job.id} queued for user ${userId}`);

--- a/closzIT-front/src/context/VtoContext.jsx
+++ b/closzIT-front/src/context/VtoContext.jsx
@@ -192,7 +192,7 @@ export const VtoProvider = ({ children }) => {
 
                             if (statusResult.status === 'completed') {
                                 const data = statusResult.result;
-                                if (data.success) {
+                                if (data && data.success) {
                                     addVtoResult({
                                         imageUrl: data.imageUrl,
                                         postId: postId,
@@ -202,6 +202,9 @@ export const VtoProvider = ({ children }) => {
                                     refreshVtoData();
                                     setToastMessage('착장 완료!');
                                     setTimeout(() => setToastMessage(''), 3000);
+                                } else if (!data) {
+                                    console.warn('[VTO] Job completed but result is null, retrying...');
+                                    continue; // 다시 polling 시도
                                 }
                                 return;
                             } else if (statusResult.status === 'failed') {


### PR DESCRIPTION
## 개요
VTO(가상 피팅) 요청이 동시에 여러 개(concurrency 설정 초과) 들어올 때, 큐잉 처리 과정에서 polling 시 결과값을 제대로 받아오지 못하는 에러를 수정했습니다.

## 문제 상황
- 4개 이상 동시 VTO 요청 시, polling 과정에서 `TypeError: Cannot read properties of null (reading 'success')` 에러 발생.
- 백엔드 API는 `completed` 상태를 반환하지만, `result` 필드가 `null`로 비어있는 현상 확인.

## 원인 분석
- **BullMQ 기본 설정**: Job이 완료(`completed`)되면 기본 설정에 의해 결과(`returnvalue`)가 즉시 삭제되거나 유지되지 않음.
- **Concurrency 제한**: `vto-queue`의 concurrency가 3으로 설정되어 있어, 4번째 요청부터는 `waiting` 상태로 대기함.
- **Timing Issue**: 대기하던 Job이 완료되는 시점이나 Polling 타이밍에 따라, BullMQ에서 이미 완료된 Job의 결과를 정리해버려 `null`이 반환됨.

## 해결 방법

### 1. 백엔드 (`fitting.controller.ts`)
- `vtoQueue.add()` 호출 시 `removeOnComplete` 옵션을 추가하여 Job 결과를 일정 기간 보존하도록 수정.
  ```typescript
  removeOnComplete: { 
      age: 300,   // 5분간 보존
      count: 100  // 최대 100개까지 보존
  },
  removeOnFail: { age: 3600 } // 실패 시 1시간 보존
  ```
- 적용 범위: `partial-try-on-by-ids`, `sns-virtual-try-on`, `sns-full-try-on` (3곳 모두 적용)

### 2. 프론트엔드 (`VtoContext.jsx`)
- Polling 로직에서 `statusResult.result`가 `null`인 경우에 대한 방어 코드 추가.
- `result`가 `null`이면 에러를 던지는 대신 경고 로그를 남기고 `continue`하여 polling을 계속 시도하도록 수정.

## 관련 워크플로우
- @[/smart-commit]
