### PR TITLE
fix: 유저 피드 게시물 이미지 크롭 방지

### DIFF
--- a/closzIT-front/src/pages/FeedPage.jsx
+++ b/closzIT-front/src/pages/FeedPage.jsx
@@ -692,7 +692,7 @@ const FeedPage = () => {
                         <img
                           src={post.imageUrl}
                           alt="Post"
-                          className="w-full h-full object-cover"
+                          className="w-full h-full object-contain"
                         />
                         {/* 호버 오버레이 */}
                         <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-4">


### PR DESCRIPTION
- object-cover에서 object-contain으로 변경
- 이미지 전체가 박스 안에 보이도록 수정
- 비율 유지하며 리사이징 적용