### PR TITLE
fix(FE): 피드 탭 새로고침 로직 최적화

### DIFF
--- a/closzIT-front/src/pages/CreatePostPage.jsx
+++ b/closzIT-front/src/pages/CreatePostPage.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import SharedHeader from '../components/SharedHeader';
+import { useTabStore, TAB_KEYS } from '../stores/tabStore';
+
 
 const API_BASE_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000';
 
@@ -20,7 +22,9 @@ const CreatePostPage = () => {
     shoes: [],
   });
   const [activeCategory, setActiveCategory] = useState('tops');
+  const { setShouldRefreshFeed, setActiveTab } = useTabStore();
   const [uploading, setUploading] = useState(false);
+
 
   // 의상 분석 관련 state
   const [isAnalyzing, setIsAnalyzing] = useState(false);
@@ -266,6 +270,8 @@ const CreatePostPage = () => {
         });
 
         if (response.ok) {
+          setShouldRefreshFeed(true);
+          setActiveTab(TAB_KEYS.FEED);
           navigate('/feed');
         } else {
           alert('게시물 수정에 실패했습니다');
@@ -287,6 +293,8 @@ const CreatePostPage = () => {
         });
 
         if (response.ok) {
+          setShouldRefreshFeed(true);
+          setActiveTab(TAB_KEYS.FEED);
           navigate('/feed');
         } else {
           alert('게시물 작성에 실패했습니다');

--- a/closzIT-front/src/pages/FeedPage.jsx
+++ b/closzIT-front/src/pages/FeedPage.jsx
@@ -15,6 +15,7 @@ const FeedPage = ({ hideHeader = false }) => {
     requestVto
   } = useVtoStore();
   const { user: currentUser, fetchUser } = useUserStore();
+  const { activeTab: globalActiveTab } = useTabStore();
 
 
   // 탭 상태 ('홈' 또는 '유저피드')
@@ -67,6 +68,22 @@ const FeedPage = ({ hideHeader = false }) => {
   useEffect(() => {
     fetchFeed();
   }, [page]);
+
+  // Feed 탭으로 돌아올 때 데이터 새로고침 (게시물 작성 후 등)
+  useEffect(() => {
+    if (globalActiveTab === TAB_KEYS.FEED) {
+      // 피드 데이터 새로고침
+      setPage(1);
+      setLoading(true);
+      fetchFeed();
+      
+      // 유저 피드 탭이 활성화되어 있으면 유저 게시물도 새로고침
+      if (activeTab === '유저피드' && currentUser) {
+        fetchUserPosts();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [globalActiveTab]);
 
   // 탭 변경 시 유저 게시물 가져오기
   useEffect(() => {

--- a/closzIT-front/src/pages/FeedPage.jsx
+++ b/closzIT-front/src/pages/FeedPage.jsx
@@ -15,7 +15,11 @@ const FeedPage = ({ hideHeader = false }) => {
     requestVto
   } = useVtoStore();
   const { user: currentUser, fetchUser } = useUserStore();
-  const { activeTab: globalActiveTab } = useTabStore();
+  const { 
+    activeTab: globalActiveTab, 
+    shouldRefreshFeed, 
+    setShouldRefreshFeed 
+  } = useTabStore();
 
 
   // 탭 상태 ('홈' 또는 '유저피드')
@@ -71,7 +75,7 @@ const FeedPage = ({ hideHeader = false }) => {
 
   // Feed 탭으로 돌아올 때 데이터 새로고침 (게시물 작성 후 등)
   useEffect(() => {
-    if (globalActiveTab === TAB_KEYS.FEED) {
+    if (globalActiveTab === TAB_KEYS.FEED && shouldRefreshFeed) {
       // 피드 데이터 새로고침
       setPage(1);
       setLoading(true);
@@ -81,9 +85,12 @@ const FeedPage = ({ hideHeader = false }) => {
       if (activeTab === '유저피드' && currentUser) {
         fetchUserPosts();
       }
+
+      // 새로고침 플래그 초기화
+      setShouldRefreshFeed(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [globalActiveTab]);
+  }, [globalActiveTab, shouldRefreshFeed]);
 
   // 탭 변경 시 유저 게시물 가져오기
   useEffect(() => {

--- a/closzIT-front/src/pages/FittingRoomPage.jsx
+++ b/closzIT-front/src/pages/FittingRoomPage.jsx
@@ -241,44 +241,52 @@ const FittingRoomPage = ({ hideHeader = false }) => {
     }
   }, [storeFullBodyImage]);
 
-  // 옷장 현황 API 호출
-  useEffect(() => {
-    const fetchWardrobeStats = async () => {
-      try {
-        const token = localStorage.getItem('accessToken');
-        if (!token) return;
+  // 옷장 현황 API 호출 함수
+  const fetchWardrobeStats = async () => {
+    try {
+      const token = localStorage.getItem('accessToken');
+      if (!token) return;
 
-        const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000';
-        const response = await fetch(`${backendUrl}/items/by-category`, {
-          headers: { 'Authorization': `Bearer ${token}` },
+      const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000';
+      const response = await fetch(`${backendUrl}/items/by-category`, {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        const stats = {
+          outerwear: data.outerwear?.length || 0,
+          tops: data.tops?.length || 0,
+          bottoms: data.bottoms?.length || 0,
+          shoes: data.shoes?.length || 0,
+          total: (data.outerwear?.length || 0) + (data.tops?.length || 0) +
+            (data.bottoms?.length || 0) + (data.shoes?.length || 0),
+        };
+
+        setWardrobeStats(stats);
+        setUserClothes({
+          outerwear: (data.outerwear || []).map(item => ({ ...item, category: 'outerwear' })),
+          tops: (data.tops || []).map(item => ({ ...item, category: 'tops' })),
+          bottoms: (data.bottoms || []).map(item => ({ ...item, category: 'bottoms' })),
+          shoes: (data.shoes || []).map(item => ({ ...item, category: 'shoes' })),
         });
-
-        if (response.ok) {
-          const data = await response.json();
-          const stats = {
-            outerwear: data.outerwear?.length || 0,
-            tops: data.tops?.length || 0,
-            bottoms: data.bottoms?.length || 0,
-            shoes: data.shoes?.length || 0,
-            total: (data.outerwear?.length || 0) + (data.tops?.length || 0) +
-              (data.bottoms?.length || 0) + (data.shoes?.length || 0),
-          };
-
-          setWardrobeStats(stats);
-          setUserClothes({
-            outerwear: (data.outerwear || []).map(item => ({ ...item, category: 'outerwear' })),
-            tops: (data.tops || []).map(item => ({ ...item, category: 'tops' })),
-            bottoms: (data.bottoms || []).map(item => ({ ...item, category: 'bottoms' })),
-            shoes: (data.shoes || []).map(item => ({ ...item, category: 'shoes' })),
-          });
-        }
-      } catch (error) {
-        console.error('Wardrobe API error:', error);
       }
-    };
+    } catch (error) {
+      console.error('Wardrobe API error:', error);
+    }
+  };
 
+  // 초기 로드
+  useEffect(() => {
     fetchWardrobeStats();
   }, []);
+
+  // FittingRoom 탭으로 돌아올 때 데이터 새로고침
+  useEffect(() => {
+    if (activeTab === TAB_KEYS.FITTING_ROOM) {
+      fetchWardrobeStats();
+    }
+  }, [activeTab]);
 
   return (
     <div className="min-h-screen bg-cream dark:bg-[#1A1918] pb-20">

--- a/closzIT-front/src/stores/tabStore.js
+++ b/closzIT-front/src/stores/tabStore.js
@@ -35,6 +35,11 @@ export const useTabStore = create((set, get) => ({
         set({ pendingTryOnCloth: null });
         return cloth;
     },
+
+    // 피드 탭 새로고침 트리거
+    shouldRefreshFeed: false,
+    setShouldRefreshFeed: (shouldRefresh) => set({ shouldRefreshFeed: shouldRefresh }),
+    
     
     // 탭 변경
     setActiveTab: (tab) => {


### PR DESCRIPTION
## 🔍 변경 사항
- **UX 개선: 피드 탭 새로고침 최적화**:
  - `tabStore`에 `shouldRefreshFeed` 플래그 도입.
  - 단순 탭 이동 시에는 피드 상태 유지 (새로고침 방지).
  - `CreatePostPage`에서 게시물 작성/수정 완료 시에만 `shouldRefreshFeed` 플래그를 활성화.
  - `FeedPage` 탭 활성화 시 플래그를 확인하여 필요한 경우에만 데이터 갱신 및 플래그 초기화.

## 📂 파일 목록
- `closzIT-front/src/stores/tabStore.js`
- `closzIT-front/src/pages/FeedPage.jsx`
- `closzIT-front/src/pages/CreatePostPage.jsx`

## ⚠️ 머지 가이드라인
- 이번 PR은 **이미 머지된 #186 PR 이후의 최적화 작업**입니다.
- `dev` 브랜치에 안전하게 머지 가능합니다.
