### PR TITLE
feat: SNS 페이지 팔로워 기능 및 피드 UI 개선

### DIFF
--- a/closzIT-front/src/components/FollowerListModal.jsx
+++ b/closzIT-front/src/components/FollowerListModal.jsx
@@ -1,0 +1,113 @@
+// src/components/FollowerListModal.jsx
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const FollowerListModal = ({
+    isOpen,
+    followers = [],
+    onClose,
+    currentUserId
+}) => {
+    const navigate = useNavigate();
+
+    if (!isOpen) return null;
+
+    const handleUserClick = (userId) => {
+        // 본인 피드인 경우 이동하지 않음 (선택사항, 기획에 따라 다름)
+        // 여기서는 클릭 시 해당 유저의 피드로 이동
+        if (userId === currentUserId) {
+            // 이미 본인이면 닫기만 함
+            onClose();
+            return;
+        }
+        navigate(`/feed/${userId}`);
+        onClose();
+    };
+
+    return (
+        <div
+            className="fixed inset-0 bg-black/80 backdrop-blur-sm z-[100] flex items-center justify-center"
+            onClick={onClose}
+        >
+            <div
+                className="bg-warm-white dark:bg-charcoal rounded-3xl shadow-2xl w-[90%] max-w-sm overflow-hidden relative flex flex-col max-h-[60vh]"
+                onClick={(e) => e.stopPropagation()}
+            >
+                {/* 헤더 */}
+                <div className="p-5 border-b border-gold-light/20 flex items-center justify-between">
+                    <h3 className="text-xl font-bold text-charcoal dark:text-cream">
+                        팔로워 <span className="text-gold">{followers.length}</span>
+                    </h3>
+                    <button
+                        onClick={onClose}
+                        className="w-8 h-8 rounded-full hover:bg-gold-light/10 flex items-center justify-center transition-colors"
+                    >
+                        <span className="material-symbols-rounded text-charcoal-light dark:text-cream-dark">close</span>
+                    </button>
+                </div>
+
+                {/* 리스트 영역 */}
+                <div className="overflow-y-auto flex-1 p-2">
+                    {followers.length === 0 ? (
+                        <div className="py-10 text-center text-charcoal-light dark:text-cream-dark">
+                            <p>아직 팔로워가 없습니다.</p>
+                        </div>
+                    ) : (
+                        <div className="space-y-1">
+                            {followers.map(follower => (
+                                <div
+                                    key={follower.id}
+                                    onClick={() => handleUserClick(follower.id)}
+                                    className="flex items-center gap-3 p-3 rounded-xl hover:bg-gold-light/10 dark:hover:bg-charcoal-light cursor-pointer transition-colors"
+                                >
+                                    {/* 프로필 이미지 */}
+                                    <div className="w-10 h-10 rounded-full bg-gradient-to-br from-gold to-gold-dark flex items-center justify-center text-warm-white font-bold text-sm overflow-hidden flex-shrink-0">
+                                        {follower.profileImage ? (
+                                            <img
+                                                src={(() => {
+                                                    const cleanPath = follower.profileImage.trim();
+                                                    if (cleanPath.startsWith('http')) return cleanPath;
+                                                    const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000';
+                                                    const separator = !backendUrl.endsWith('/') && !cleanPath.startsWith('/') ? '/' : '';
+                                                    return `${backendUrl}${separator}${cleanPath}`;
+                                                })()}
+                                                alt={follower.name}
+                                                referrerPolicy="no-referrer"
+                                                className="w-full h-full object-cover" // 이미지를 컨테이너에 꽉 차게 리사이징 (비율 유지)
+                                                onError={(e) => {
+                                                    const parent = e.target.parentElement;
+                                                    e.target.style.display = 'none';
+                                                    if (parent) {
+                                                        parent.innerText = follower.name?.[0] || follower.email?.[0]?.toUpperCase();
+                                                        parent.classList.remove('overflow-hidden');
+                                                    }
+                                                }}
+                                            />
+                                        ) : (
+                                            follower.name?.[0] || follower.email?.[0]?.toUpperCase()
+                                        )}
+                                    </div>
+
+                                    {/* 정보 */}
+                                    <div className="flex-1 min-w-0">
+                                        <p className="font-bold text-charcoal dark:text-cream truncate">
+                                            {follower.name || '이름 없음'}
+                                        </p>
+
+                                    </div>
+
+                                    {/* 화살표 아이콘 (선택) */}
+                                    <span className="material-symbols-rounded text-gold-light/50 text-xl">
+                                        chevron_right
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default FollowerListModal;

--- a/closzIT-front/src/pages/Register/RegisterPage.jsx
+++ b/closzIT-front/src/pages/Register/RegisterPage.jsx
@@ -1,5 +1,5 @@
 import React, { useRef, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import SharedHeader from '../../components/SharedHeader';
 import BottomNav from '../../components/BottomNav';
 
@@ -41,8 +41,12 @@ const registerOptions = [
 
 const RegisterPage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const fileInputRef = useRef(null);
   const cameraInputRef = useRef(null);
+
+  // FeedPage에서 넘어온 경우 returnTo 정보 가져오기
+  const returnTo = location.state?.returnTo;
 
   // 카메라 존재 여부 확인 및 카메라 실행
   const handleCameraClick = useCallback(async () => {
@@ -151,7 +155,7 @@ const RegisterPage = () => {
       />
 
       {/* Shared Header */}
-      <SharedHeader title="등록하기" showBackButton onBackClick={() => navigate('/main')} />
+      <SharedHeader title="등록하기" showBackButton onBackClick={() => navigate(returnTo || '/main')} />
 
       {/* Main Content */}
       <main className="flex-1 px-6 py-8 flex flex-col items-center justify-center pb-28">


### PR DESCRIPTION
- 본인 팔로워 클릭 시 팔로워 리스트 모달 컴포넌트 추가
- 타인/본인 팔로워 수 표시 및 팔로우 토글 기능 구현
- Optimistic UI 업데이트로 즉각적인 사용자 경험 제공
- 빈 옷장 UI 개선
  - 옷 추가하기 버튼 중앙 정렬 및 스타일 개선
  - 본인 옷장: '옷장이 비어있습니다' 메시지 표시
  - 타인 옷장: '옷장이 비공개 상태입니다' 메시지 표시
- 홈 피드에서 자신의 프로필 또는 이름 클릭 시 본인 유저피드 탭으로 이동
- 홈 피드에서 타인의 프로필 또는 이름 클릭 시  타인 유저피드 이동
- 유저피드의 옷장 탭에서 '+ 옷 추가하기' 버튼 클릭시 RegisterPage 이동 후 뒤로가기 시 이전 페이지로 복귀 기능 추가
