### PR TITLE
feat(의상등록): YOLO/SAM2 이미지 토글 기능 추가

### DIFF
--- a/closzIT-back/src/analysis/analysis.service.ts
+++ b/closzIT-back/src/analysis/analysis.service.ts
@@ -73,7 +73,9 @@ export class AnalysisService {
                     return {
                         tempId: index, // Temporary ID for frontend key
                         label: labelData,
-                        image: item.image_base64,
+                        image: item.sam2_image_base64 || item.image_base64,
+                        yoloImage: item.yolo_image_base64,
+                        sam2Image: item.sam2_image_base64 || item.image_base64,
                         embedding: item.embedding, // Pass embedding to frontend (to send back later)
                     };
                 }),


### PR DESCRIPTION
## 개요
의상 등록 과정에서 YOLO 처리 이미지(크롭)와 SAM2 처리 이미지(배경 제거) 사이를 토글할 수 있는 기능을 추가합니다.

## 변경 사항

### 📁 ai-fastapi/main.py
- 의상 분석 API 응답에 `yolo_url`과 `sam2_url` 모두 포함하도록 수정

### 📁 closzIT-back/src/analysis/analysis.service.ts
- 백엔드에서 두 이미지 URL을 프론트엔드에 전달하도록 서비스 로직 수정

### 📁 closzIT-front/src/pages/Labeling/LabelingPage.jsx
- YOLO/SAM2 이미지 토글 UI 구현
- SAM2 이미지를 기본값으로 설정
- 선택된 이미지 타입 저장 기능

## 테스트 방법
1. 의상 등록 페이지 접속
2. 이미지 업로드 후 분석 진행
3. 분석된 의상에서 YOLO/SAM2 토글 버튼 확인
4. 토글 시 이미지가 올바르게 전환되는지 확인

## 관련 이슈
- JG-200
