### PR TITLE
fix(queue): ElastiCache 용량 초과 방지를 위한 removeOnFail 설정 추가

### DIFF
--- a/closzIT-back/src/analysis/analysis.controller.ts
+++ b/closzIT-back/src/analysis/analysis.controller.ts
@@ -82,6 +82,8 @@ export class AnalysisController {
                     type: 'exponential',
                     delay: 1000,
                 },
+                removeOnComplete: { age: 300, count: 100 }, // 5분간 또는 100개까지 보존
+                removeOnFail: { age: 3600 }, // 실패는 1시간 보존
             });
 
             this.logger.log(`[flattenClothing] Job ${job.id} queued for userId: ${userId}`);


### PR DESCRIPTION
## 개요
ElastiCache 용량 초과 문제를 해결하기 위해 BullMQ 작업 설정에 `removeOnFail` 옵션을 추가합니다.

## 문제점
- 실패한 작업들이 Redis(ElastiCache)에 계속 쌓여 용량 초과 발생
- JG-204 이슈에서 보고된 ElastiCache 메모리 부족 문제

## 해결 방법
- `analysis.controller.ts`에서 큐 작업 추가 시 `removeOnFail` 옵션 설정
- 실패한 작업이 일정 시간/개수 후 자동 삭제되도록 설정

## 변경 사항

### 📁 closzIT-back/src/analysis/analysis.controller.ts
- 큐 작업 추가 시 `removeOnFail` 옵션 추가

## 테스트 방법
1. 의상 분석 요청 후 실패 케이스 발생 유도
2. Redis에서 failed 작업이 자동 정리되는지 확인

## 관련 이슈
- JG-204
