### PR TITLE
feat(fitting): 다른 사용자 의류 입어보기 지원

### DIFF
--- a/closzIT-front/src/pages/FittingRoomPage.jsx
+++ b/closzIT-front/src/pages/FittingRoomPage.jsx
@@ -132,6 +132,7 @@ const FittingRoomPage = ({ hideHeader = false }) => {
           },
           body: JSON.stringify({
             clothingId: clothingId,
+            clothingOwnerId: tryOnCloth.userId, // 다른 사람 옷 입어보기 지원
             category: category,
             denoiseSteps: 10,
             seed: 42,
@@ -625,6 +626,7 @@ const FittingRoomPage = ({ hideHeader = false }) => {
                 },
                 body: JSON.stringify({
                   clothingId: clothingId,
+                  clothingOwnerId: selectedClothDetail.userId, // 다른 사람 옷 입어보기 지원
                   category: category,
                   denoiseSteps: 10,
                   seed: 42,


### PR DESCRIPTION
## 📋 개요

`single-item-tryon` 엔드포인트에서 **다른 사용자의 의류도 입어볼 수 있도록** 기능을 확장했습니다.

## 🔧 주요 변경사항

### Backend (`fitting.controller.ts`)
- `singleItemTryOn` 엔드포인트에 `clothingOwnerId` 파라미터 추가
- 의류 조회 시 `userId` 필터 제거하여 타 사용자 의류 접근 가능
- garment/text 캐시를 의류 소유자 기준으로 저장/조회
- `generateTryOnV2` 호출 시 `clothingOwnerId` 전달

### Frontend (`FittingRoomPage.jsx`)
- Auto try-on 및 Modal try-on API 호출 시 `clothingOwnerId` 전달
- `tryOnCloth.userId` 또는 `selectedClothDetail.userId`를 사용

## 📁 변경된 파일

| 파일 | 변경 내용 |
|------|----------|
| `closzIT-back/src/fitting/fitting.controller.ts` | clothingOwnerId 파라미터 및 로직 추가 |
| `closzIT-front/src/pages/FittingRoomPage.jsx` | API 호출 시 clothingOwnerId 전달 |

## ✅ 테스트 방법

1. 피드에서 다른 사용자의 옷장 확인
2. 다른 사용자의 옷 클릭 후 "입어보기" 실행
3. 정상적으로 가상 피팅 결과가 표시되는지 확인

## 🔗 관련 이슈

- 기존 `single-item-tryon`은 본인 의류만 조회 가능했음
- SNS에서 다른 사용자 옷을 원터치 착장할 때 400 에러 발생
