### PR TITLE
fix(fitting): S3 클라이언트 리전을 AWS_S3_REGION으로 변경

### DIFF
--- a/closzIT-back/src/fitting/fitting.controller.ts
+++ b/closzIT-back/src/fitting/fitting.controller.ts
@@ -35,7 +35,7 @@ export class FittingController {
   ) {
     // S3 Client 초기화
     this.s3Client = new S3Client({
-      region: process.env.AWS_REGION || 'ap-northeast-2',
+      region: process.env.AWS_S3_REGION || 'ap-northeast-2',
       credentials: {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,


### PR DESCRIPTION
## 📋 개요

S3 클라이언트 초기화 시 사용하는 리전 환경변수를 `.env` 파일의 변수명과 일치하도록 수정했습니다.

## 🔧 변경사항

```diff
- region: process.env.AWS_REGION || 'ap-northeast-2',
+ region: process.env.AWS_S3_REGION || 'ap-northeast-2',
```

## 📁 변경된 파일

| 파일 | 변경 내용 |
|------|----------|
| `closzIT-back/src/fitting/fitting.controller.ts` | S3Client 리전을 AWS_S3_REGION으로 변경 |

## ✅ 변경 이유

| 환경변수 | 값 | 용도 |
|---------|-----|------|
| `AWS_REGION` | `ap-northeast-1` (도쿄) | AI 서버용 |
| `AWS_S3_REGION` | `ap-northeast-2` (서울) | **S3 버킷 위치** |

S3 버킷이 서울 리전에 있으므로 `AWS_S3_REGION`을 사용해야 정상 동작합니다.
