### PR TITLE
fix: 로그인/옷등록 새로고침, enum 매핑, Wedding TPO 추가

### DIFF
--- a/closzIT-back/src/items/items.service.ts
+++ b/closzIT-back/src/items/items.service.ts
@@ -2,6 +2,40 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { S3Service } from '../s3/s3.service';
 
+// DB 값 (하이픈 포함) → Prisma enum 이름 매핑
+const ENUM_MAPPINGS: Record<string, string> = {
+  // Color
+  'Sky-blue': 'SkyBlue',
+  // SubCategory
+  'Hoodie-zipup': 'HoodieZipup',
+  'Short-sleeve-T': 'ShortSleeveT',
+  'Long-sleeve-T': 'LongSleeveT',
+  'Polo-shirt': 'PoloShirt',
+  'Cotton-pants': 'CottonPants',
+  'Dress-shoes': 'DressShoes',
+  // Detail
+  'Knit-rib': 'KnitRib',
+};
+
+// 역방향 매핑 (Prisma enum 이름 → DB 값)
+const REVERSE_ENUM_MAPPINGS: Record<string, string> = Object.fromEntries(
+  Object.entries(ENUM_MAPPINGS).map(([db, prisma]) => [prisma, db])
+);
+
+// 단일 값 변환 (DB → Prisma)
+const toPrismaEnum = (value: string): string => ENUM_MAPPINGS[value] || value;
+
+// 단일 값 변환 (Prisma → DB)
+const toDbEnum = (value: string): string => REVERSE_ENUM_MAPPINGS[value] || value;
+
+// 배열 값 변환 (DB → Prisma)
+const toPrismaEnumArray = (values: string[] | undefined): string[] | undefined => 
+  values?.map(toPrismaEnum);
+
+// 배열 값 변환 (Prisma → DB)
+const toDbEnumArray = (values: string[] | undefined): string[] | undefined => 
+  values?.map(toDbEnum);
+
 @Injectable()
 export class ItemsService {
   constructor(
@@ -52,19 +86,19 @@ export class ItemsService {
 
         return {
           id: item.id,
-          name: item.subCategory,
+          name: toDbEnum(item.subCategory),
           // 펼쳐진 이미지가 있으면 우선 사용, 없으면 원본 이미지
           image: flattenImageUrl || imageUrl,
           originalImage: imageUrl,
           flattenImage: flattenImageUrl,
-          category: item.category,
-          subCategory: item.subCategory,
-          colors: item.colors,
-          patterns: item.patterns,
-          details: item.details,
-          styleMoods: item.styleMoods,
-          tpos: item.tpos,
-          seasons: item.seasons,
+          category: toDbEnum(item.category),
+          subCategory: toDbEnum(item.subCategory),
+          colors: toDbEnumArray(item.colors as string[]),
+          patterns: toDbEnumArray(item.patterns as string[]),
+          details: toDbEnumArray(item.details as string[]),
+          styleMoods: toDbEnumArray(item.styleMoods as string[]),
+          tpos: toDbEnumArray(item.tpos as string[]),
+          seasons: toDbEnumArray(item.seasons as string[]),
           userRating: item.userRating,
           note: item.note,
           isPublic: item.isPublic,
@@ -140,18 +174,18 @@ export class ItemsService {
 
         return {
           id: item.id,
-          name: item.subCategory,
+          name: toDbEnum(item.subCategory),
           image: flattenImageUrl || imageUrl,
           originalImage: imageUrl,
           flattenImage: flattenImageUrl,
-          category: item.category,
-          subCategory: item.subCategory,
-          colors: item.colors,
-          patterns: item.patterns,
-          details: item.details,
-          styleMoods: item.styleMoods,
-          tpos: item.tpos,
-          seasons: item.seasons,
+          category: toDbEnum(item.category),
+          subCategory: toDbEnum(item.subCategory),
+          colors: toDbEnumArray(item.colors as string[]),
+          patterns: toDbEnumArray(item.patterns as string[]),
+          details: toDbEnumArray(item.details as string[]),
+          styleMoods: toDbEnumArray(item.styleMoods as string[]),
+          tpos: toDbEnumArray(item.tpos as string[]),
+          seasons: toDbEnumArray(item.seasons as string[]),
           userRating: item.userRating,
           note: item.note,
           isPublic: item.isPublic,
@@ -217,18 +251,18 @@ export class ItemsService {
 
     return {
       id: item.id,
-      name: item.subCategory,
+      name: toDbEnum(item.subCategory),
       image: flattenImageUrl || imageUrl,
       originalImage: imageUrl,
       flattenImage: flattenImageUrl,
-      category: item.category,
-      subCategory: item.subCategory,
-      colors: item.colors,
-      patterns: item.patterns,
-      details: item.details,
-      styleMoods: item.styleMoods,
-      tpos: item.tpos,
-      seasons: item.seasons,
+      category: toDbEnum(item.category),
+      subCategory: toDbEnum(item.subCategory),
+      colors: toDbEnumArray(item.colors as string[]),
+      patterns: toDbEnumArray(item.patterns as string[]),
+      details: toDbEnumArray(item.details as string[]),
+      styleMoods: toDbEnumArray(item.styleMoods as string[]),
+      tpos: toDbEnumArray(item.tpos as string[]),
+      seasons: toDbEnumArray(item.seasons as string[]),
       userRating: item.userRating,
       note: item.note,
       isPublic: item.isPublic,
@@ -261,14 +295,14 @@ export class ItemsService {
     return this.prisma.clothing.update({
       where: { id: itemId },
       data: {
-        category: data.category,
-        subCategory: data.subCategory,
-        colors: data.colors as any,
-        patterns: data.patterns as any,
-        details: data.details as any,
-        styleMoods: data.styleMoods as any,
-        tpos: data.tpos as any,
-        seasons: data.seasons as any,
+        category: data.category ? toPrismaEnum(data.category) as any : undefined,
+        subCategory: data.subCategory ? toPrismaEnum(data.subCategory) : undefined,
+        colors: toPrismaEnumArray(data.colors) as any,
+        patterns: toPrismaEnumArray(data.patterns) as any,
+        details: toPrismaEnumArray(data.details) as any,
+        styleMoods: toPrismaEnumArray(data.styleMoods) as any,
+        tpos: toPrismaEnumArray(data.tpos) as any,
+        seasons: toPrismaEnumArray(data.seasons) as any,
         note: data.note,
       },
     });

--- a/closzIT-front/src/components/ClothDetailModal.jsx
+++ b/closzIT-front/src/components/ClothDetailModal.jsx
@@ -171,27 +171,16 @@ const ClothDetailModal = ({
               {renderInfoSection('색상', translateValue('colors', cloth.colors))}
               {cloth.wearCount !== undefined && renderInfoSection('착용 횟수', `${cloth.wearCount}회`)}
               
-              {/* 수정/삭제 버튼 - 상세 정보 안에 */}
-              {showActions && (onEdit || onDelete) && (
-                <div className="flex gap-2 pt-2">
-                  {onEdit && (
-                    <button
-                      onClick={onEdit}
-                      className="flex-1 py-2.5 bg-gold/20 text-gold rounded-xl font-semibold hover:bg-gold/30 transition-colors flex items-center justify-center gap-2 text-sm"
-                    >
-                      <span className="material-symbols-rounded text-base">edit</span>
-                      수정
-                    </button>
-                  )}
-                  {onDelete && (
-                    <button
-                      onClick={onDelete}
-                      className="flex-1 py-2.5 bg-red-50 text-red-500 rounded-xl font-semibold hover:bg-red-100 transition-colors flex items-center justify-center gap-2 text-sm"
-                    >
-                      <span className="material-symbols-rounded text-base">delete</span>
-                      삭제
-                    </button>
-                  )}
+              {/* 삭제 버튼 - 상세 정보 안에 */}
+              {showActions && onDelete && (
+                <div className="pt-2">
+                  <button
+                    onClick={onDelete}
+                    className="w-full py-2.5 bg-red-50 text-red-500 rounded-xl font-semibold hover:bg-red-100 transition-colors flex items-center justify-center gap-2 text-sm"
+                  >
+                    <span className="material-symbols-rounded text-base">delete</span>
+                    삭제
+                  </button>
                 </div>
               )}
             </div>

--- a/closzIT-front/src/pages/FittingRoomPage.jsx
+++ b/closzIT-front/src/pages/FittingRoomPage.jsx
@@ -41,8 +41,9 @@ const keywordGroups = [
     options: [
       { label: '데일리', value: 'Daily' }, { label: '출근', value: 'Commute' },
       { label: '데이트', value: 'Date' }, { label: '운동', value: 'Sports' },
-      { label: '여행', value: 'Travel' }, { label: '파티', value: 'Party' },
-      { label: '학교', value: 'School' }, { label: '집', value: 'Home' }
+      { label: '여행', value: 'Travel' }, { label: '결혼식', value: 'Wedding' },
+      { label: '파티', value: 'Party' }, { label: '학교', value: 'School' },
+      { label: '집', value: 'Home' }
     ]
   },
   {

--- a/closzIT-front/src/pages/ItemEdit/ItemEditPage.jsx
+++ b/closzIT-front/src/pages/ItemEdit/ItemEditPage.jsx
@@ -44,6 +44,7 @@ const tpoOptions = [
   { label: '데이트', value: 'Date' },
   { label: '운동', value: 'Sports' },
   { label: '여행', value: 'Travel' },
+  { label: '결혼식', value: 'Wedding' },
   { label: '파티', value: 'Party' },
   { label: '학교', value: 'School' },
   { label: '집', value: 'Home' }

--- a/closzIT-front/src/pages/Labeling/LabelingPage.jsx
+++ b/closzIT-front/src/pages/Labeling/LabelingPage.jsx
@@ -45,6 +45,7 @@ const tpoOptions = [
   { label: '데이트', value: 'Date' },
   { label: '운동', value: 'Sports' },
   { label: '여행', value: 'Travel' },
+  { label: '결혼식', value: 'Wedding' },
   { label: '파티', value: 'Party' },
   { label: '학교', value: 'School' },
   { label: '집', value: 'Home' }
@@ -816,7 +817,8 @@ const LabelingPage = () => {
             <button
               onClick={() => {
                 setShowSuccessPopup(false);
-                navigate('/main');
+                // 전체 페이지 새로고침으로 메인 데이터 갱신
+                window.location.href = '/main';
               }}
               className="w-full py-3.5 rounded-xl font-bold text-white transition-all hover:scale-[1.02] active:scale-[0.98]"
               style={{

--- a/closzIT-front/src/pages/Login/AuthCallbackPage.jsx
+++ b/closzIT-front/src/pages/Login/AuthCallbackPage.jsx
@@ -23,7 +23,8 @@ const AuthCallbackPage = () => {
       return;
     }
 
-    navigate(redirect, { replace: true });
+    // 최초 로그인 시 전체 페이지 새로고침으로 appStore 초기화
+    window.location.href = redirect;
   }, [searchParams, navigate]);
 
   return (

--- a/closzIT-front/src/pages/Main/MainPage2.jsx
+++ b/closzIT-front/src/pages/Main/MainPage2.jsx
@@ -29,8 +29,9 @@ const keywordGroups = [
     options: [
       { label: '데일리', value: 'Daily' }, { label: '출근', value: 'Commute' },
       { label: '데이트', value: 'Date' }, { label: '운동', value: 'Sports' },
-      { label: '여행', value: 'Travel' }, { label: '파티', value: 'Party' },
-      { label: '학교', value: 'School' }, { label: '집', value: 'Home' }
+      { label: '여행', value: 'Travel' }, { label: '결혼식', value: 'Wedding' },
+      { label: '파티', value: 'Party' }, { label: '학교', value: 'School' },
+      { label: '집', value: 'Home' }
     ]
   },
   {


### PR DESCRIPTION
## 변경 사항

### 🔧 버그 수정
- **최초 로그인 시 데이터 미로드 문제 해결**: `AuthCallbackPage`에서 `navigate()` 대신 `window.location.href`로 전체 페이지 새로고침 적용
- **옷 등록 후 메인 데이터 갱신**: `LabelingPage`에서 등록 완료 후 새로고침으로 옷장 데이터 즉시 반영
- **스카이블루 등 하이픈 포함 enum 처리**: `items.service.ts`에 Prisma ↔ DB 양방향 enum 변환 로직 추가
  - 저장 시: `Sky-blue` → `SkyBlue` (Prisma 형식)
  - 조회 시: `SkyBlue` → `Sky-blue` (프론트엔드 호환)

### ✨ 기능 추가
- **TPO 옵션에 결혼식(Wedding) 추가**: DB/백엔드에 있던 Wedding 옵션을 프론트엔드 4개 파일에도 추가
  - `LabelingPage.jsx`, `ItemEditPage.jsx`, `MainPage2.jsx`, `FittingRoomPage.jsx`

### 🎨 UI 개선
- **ClothDetailModal 중복 버튼 제거**: 상세정보 내 수정 버튼 제거 (상단 "옷 정보 수정하기" 버튼 유지)

---

## 변경된 파일
| 파일 | 변경 내용 |
|------|-----------|
| `closzIT-back/src/items/items.service.ts` | enum 양방향 매핑 함수 추가 및 조회 함수에 적용 |
| `closzIT-front/src/components/ClothDetailModal.jsx` | 중복 수정 버튼 제거 |
| `closzIT-front/src/pages/Login/AuthCallbackPage.jsx` | 로그인 후 새로고침 적용 |
| `closzIT-front/src/pages/Labeling/LabelingPage.jsx` | 등록 완료 후 새로고침 + Wedding TPO 추가 |
| `closzIT-front/src/pages/ItemEdit/ItemEditPage.jsx` | Wedding TPO 추가 |
| `closzIT-front/src/pages/Main/MainPage2.jsx` | Wedding TPO 추가 |
| `closzIT-front/src/pages/FittingRoomPage.jsx` | Wedding TPO 추가 |

---

## 머지 가이드라인
- `dev` 브랜치로 머지
- 충돌 시 백엔드 `items.service.ts`의 enum 매핑 로직 주의
