### PR TITLE
feat: 통합 FAB 버튼 및 최근 등록 UI 개선

### DIFF
--- a/closzIT-front/src/components/BottomNav.jsx
+++ b/closzIT-front/src/components/BottomNav.jsx
@@ -1,19 +1,17 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useTabStore, TAB_KEYS } from '../stores/tabStore';
 
 /**
  * 공유 하단 네비게이션 컴포넌트
  * 멀티탭 방식 지원 - 메인 탭들은 탭 전환으로, 다른 페이지는 navigate로 이동
- * @param {Object} props
- * @param {Object} props.floatingAction - 플로팅 액션 버튼 설정 (선택적)
- * @param {string} props.floatingAction.icon - Material Symbols 아이콘 이름
- * @param {Function} props.floatingAction.onClick - 클릭 핸들러
+ * 통합 FAB 버튼: 옷 등록 / 피드 등록 선택 가능
  */
 const BottomNav = ({ floatingAction }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { activeTab, setActiveTab } = useTabStore();
+  const [isFabOpen, setIsFabOpen] = useState(false);
 
   // 현재 멀티탭 컨테이너 안에 있는지 확인
   const isInMultiTab = location.pathname === '/main' || 
@@ -46,16 +44,81 @@ const BottomNav = ({ floatingAction }) => {
     }
   };
 
+  // 옷 등록 클릭
+  const handleClothRegister = () => {
+    setIsFabOpen(false);
+    navigate('/register');
+  };
+
+  // 피드 등록 클릭
+  const handleFeedRegister = () => {
+    setIsFabOpen(false);
+    // SNS 탭으로 이동 후 새로고침 (최근 등록 피드 표시)
+    if (isInMultiTab) {
+      setActiveTab(TAB_KEYS.FEED);
+      window.history.replaceState(null, '', '/feed');
+    }
+    navigate('/create-post');
+  };
+
   return (
     <>
-      {/* Floating Action Button (선택적) */}
+      {/* 배경 오버레이 */}
+      {isFabOpen && (
+        <div 
+          className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40 animate-fadeIn"
+          onClick={() => setIsFabOpen(false)}
+        />
+      )}
+
+      {/* 통합 FAB 버튼 영역 */}
       {floatingAction && (
-        <button
-          onClick={floatingAction.onClick}
-          className="fixed bottom-20 right-4 w-14 h-14 btn-premium rounded-full shadow-lg hover:shadow-xl hover:scale-110 active:scale-95 transition-all z-50 flex items-center justify-center"
-        >
-          <span className="material-symbols-rounded text-2xl">{floatingAction.icon}</span>
-        </button>
+        <div className="fixed bottom-20 right-4 z-50">
+          {/* 확장 메뉴 */}
+          <div className={`absolute bottom-16 right-0 flex flex-col gap-3 transition-all duration-300 ${
+            isFabOpen 
+              ? 'opacity-100 translate-y-0 pointer-events-auto' 
+              : 'opacity-0 translate-y-4 pointer-events-none'
+          }`}>
+            {/* 옷 등록 옵션 */}
+            <button
+              onClick={handleClothRegister}
+              className="flex items-center gap-3 px-4 py-3 bg-white rounded-2xl shadow-lg hover:shadow-xl hover:scale-105 active:scale-95 transition-all whitespace-nowrap"
+            >
+              <span className="w-10 h-10 bg-gold/10 rounded-xl flex items-center justify-center">
+                <span className="material-symbols-rounded text-gold text-xl">checkroom</span>
+              </span>
+              <span className="text-charcoal font-semibold">옷 등록</span>
+            </button>
+
+            {/* 피드 등록 옵션 */}
+            <button
+              onClick={handleFeedRegister}
+              className="flex items-center gap-3 px-4 py-3 bg-white rounded-2xl shadow-lg hover:shadow-xl hover:scale-105 active:scale-95 transition-all whitespace-nowrap"
+            >
+              <span className="w-10 h-10 bg-orange-100 rounded-xl flex items-center justify-center">
+                <span className="material-symbols-rounded text-orange-500 text-xl">post_add</span>
+              </span>
+              <span className="text-charcoal font-semibold">피드 작성</span>
+            </button>
+          </div>
+
+          {/* 메인 FAB 버튼 */}
+          <button
+            onClick={() => setIsFabOpen(!isFabOpen)}
+            className={`rounded-full shadow-lg hover:shadow-xl transition-all duration-300 flex items-center justify-center ${
+              isFabOpen 
+                ? 'bg-white w-12 h-12' 
+                : 'btn-premium w-14 h-14 hover:scale-110 active:scale-95'
+            }`}
+          >
+            <span className={`material-symbols-rounded transition-all duration-300 ${
+              isFabOpen ? 'text-charcoal text-xl rotate-90' : 'text-white text-2xl'
+            }`}>
+              {isFabOpen ? 'close' : 'add'}
+            </span>
+          </button>
+        </div>
       )}
 
       {/* Bottom Navigation - 3 buttons */}

--- a/closzIT-front/src/components/MultiTabContainer.jsx
+++ b/closzIT-front/src/components/MultiTabContainer.jsx
@@ -82,23 +82,15 @@ const MultiTabContainer = () => {
     const navigate = useNavigate();
     const { activeTab, previousTab, slideDirection, setActiveTab, isTabInitialized } = useTabStore();
 
-    // 각 탭별 floatingAction 설정
+    // 통합 FAB 활성화 (모든 메인 탭에서 동일하게 표시)
     const getFloatingAction = () => {
-        switch (activeTab) {
-            case TAB_KEYS.MAIN:
-            case TAB_KEYS.FITTING_ROOM:
-                return {
-                    icon: 'apparel',
-                    onClick: () => navigate('/register')
-                };
-            case TAB_KEYS.FEED:
-                return {
-                    icon: 'post_add',
-                    onClick: () => navigate('/create-post')
-                };
-            default:
-                return null;
+        // 메인 3개 탭 모두에서 통합 FAB 표시
+        if (activeTab === TAB_KEYS.MAIN || 
+            activeTab === TAB_KEYS.FITTING_ROOM || 
+            activeTab === TAB_KEYS.FEED) {
+            return { enabled: true };
         }
+        return null;
     };
 
     // URL 경로에 따라 탭 초기화 (최초 진입 시)


### PR DESCRIPTION
## 변경 사항

### ✨ 기능 추가
- **통합 FAB 버튼**: 메인/피팅룸/SNS 탭의 우측 하단 버튼을 하나로 통합
  - + 버튼 클릭 시 확장 메뉴 표시
  - **옷 등록**: `/register` 페이지로 이동
  - **피드 작성**: `/create-post` 페이지로 이동
  - 배경 블러 오버레이 + 부드러운 애니메이션

### 🎨 UI 개선
- **최근 등록 컴포넌트**:
  - 삭제 시 즉시 UI 반영 (userClothes props 사용)
  - 호버 시 수동 스와이프 모드 추가
  - 신발도 다른 옷과 동일하게 옷걸이에 표시 (배지 아이콘 제거)
- **FAB 버튼**: X 상태일 때 버튼/아이콘 크기 축소 + 90도 회전 효과

---

## 변경된 파일
| 파일 | 변경 내용 |
|------|-----------|
| `BottomNav.jsx` | 확장형 통합 FAB 버튼 구현 |
| `MultiTabContainer.jsx` | 모든 탭에서 통합 FAB 표시하도록 단순화 |
| `RecentlyAddedClothes.jsx` | props 기반 렌더링, 스와이프 모드, 신발 UI 통일 |

---

## 머지 가이드라인
- `dev` 브랜치로 머지
- BottomNav의 새로운 FAB 로직 확인 필요
