### PR TITLE
fix(queue): VTO/Flatten 동시 요청 시 안정성 개선

### DIFF
--- a/closzIT-front/src/pages/Labeling/LabelingPage.jsx
+++ b/closzIT-front/src/pages/Labeling/LabelingPage.jsx
@@ -489,6 +489,10 @@ const LabelingPage = () => {
                     fetchUser(true);
                   }
                   return; // 성공적으로 완료
+                } else if (!statusResult.result) {
+                  // result가 아직 Redis에서 로드되지 않은 경우 → 다음 poll 대기
+                  console.log('[DEBUG] Job completed but result not yet available, continuing poll...');
+                  continue;
                 } else {
                   throw new Error('No flattened image in result');
                 }


### PR DESCRIPTION
## 📋 개요

VTO(가상착장) 및 Flatten(옷펴기) 동시 요청 시 발생하던 안정성 문제를 개선합니다.

## 🔧 변경 사항

### closzIT-back

#### vto.processor.ts
- 재시도 로직에 설명 주석 추가 (HttpException 메시지, 재시도 대기 시간)

### closzIT-front

#### LabelingPage.jsx
- Job `completed` 상태이지만 `result`가 아직 Redis에서 로드되지 않은 경우 polling 계속하도록 수정
- 기존: `result`가 없으면 즉시 에러 throw
- 수정: `result`가 없으면 다음 poll 대기

#### vtoStore.js
- 관련 변경사항 반영

## 🐛 해결된 이슈

- VTO/Flatten 동시 다중 요청 시 "No flattened image in result" 에러 발생 문제
  - 원인: Job이 completed 상태가 되었으나 Redis에서 result를 아직 가져오지 못한 타이밍 이슈
  - 해결: result가 없는 경우 에러 대신 polling 계속

## 📁 변경된 파일

| 파일 | 변경 내용 |
|------|----------|
| `closzIT-back/src/queue/processors/vto.processor.ts` | 주석 추가 |
| `closzIT-front/src/pages/Labeling/LabelingPage.jsx` | result 로딩 대기 로직 추가 |
| `closzIT-front/src/stores/vtoStore.js` | 관련 변경사항 |

## ✅ 테스트

- [ ] VTO 동시 다중 요청 시 정상 동작 확인
- [ ] Flatten 동시 다중 요청 시 정상 동작 확인
