### PR TITLE
refactor(sns): 피드 페이지 의상 태그 이미지 표시 수정

### DIFF
--- a/closzIT-front/src/components/ClothDetailModal.jsx
+++ b/closzIT-front/src/components/ClothDetailModal.jsx
@@ -65,20 +65,20 @@ const translateValue = (type, value) => {
   if (!value) return null;
   const map = translations[type];
   if (!map) return value;
-  
+
   if (Array.isArray(value)) {
     return value.map(v => map[v] || v).join(', ');
   }
   return map[value] || value;
 };
 
-const ClothDetailModal = ({ 
-  cloth, 
-  onClose, 
-  onTryOn, 
-  onEdit, 
+const ClothDetailModal = ({
+  cloth,
+  onClose,
+  onTryOn,
+  onEdit,
   onDelete,
-  showActions = true 
+  showActions = true
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -115,17 +115,17 @@ const ClothDetailModal = ({
         </button>
 
         {/* 이미지 영역 - 높이 우선 (object-contain) */}
-        <div 
+        <div
           className="relative bg-charcoal/10 flex-shrink-0 transition-all duration-300 ease-out"
           style={{ height: isExpanded ? '180px' : '400px' }}
         >
           <img
-            src={cloth.image || cloth.imageUrl}
+            src={cloth.flattenImageUrl || cloth.image || cloth.imageUrl}
             alt={cloth.name}
             className="w-full h-full object-contain"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent pointer-events-none" />
-          
+
           {/* 이름 오버레이 */}
           <div className="absolute bottom-3 left-4 right-4">
             <h3 className="text-white text-xl font-bold drop-shadow-lg">{cloth.name || '의류'}</h3>
@@ -161,7 +161,7 @@ const ClothDetailModal = ({
           )}
 
           {/* 상세 정보 콘텐츠 (토글) */}
-          <div 
+          <div
             className={`overflow-hidden transition-all duration-300 ease-out ${isExpanded ? 'max-h-[400px] opacity-100' : 'max-h-0 opacity-0'}`}
           >
             <div className="p-4 space-y-2 max-h-[250px] overflow-y-auto">
@@ -170,7 +170,7 @@ const ClothDetailModal = ({
               {renderInfoSection('계절', translateValue('seasons', cloth.seasons))}
               {renderInfoSection('색상', translateValue('colors', cloth.colors))}
               {cloth.wearCount !== undefined && renderInfoSection('착용 횟수', `${cloth.wearCount}회`)}
-              
+
               {/* 삭제 버튼 - 상세 정보 안에 */}
               {showActions && onDelete && (
                 <div className="pt-2">

--- a/closzIT-front/src/pages/PostDetailPage.jsx
+++ b/closzIT-front/src/pages/PostDetailPage.jsx
@@ -241,7 +241,7 @@ const PostDetailPage = () => {
                     className="group/cloth-card relative aspect-square rounded-lg overflow-hidden bg-cream-dark dark:bg-charcoal-light shadow-soft border border-gold-light/30 hover:border-gold transition-all"
                   >
                     <img
-                      src={pc.clothing.imageUrl}
+                      src={pc.clothing.flattenImageUrl || pc.clothing.imageUrl}
                       alt={pc.clothing.subCategory}
                       className="w-full h-full object-cover"
                     />
@@ -383,7 +383,7 @@ const PostDetailPage = () => {
         <ClothDetailModal
           cloth={{
             ...selectedClothDetail,
-            image: selectedClothDetail.image || selectedClothDetail.imageUrl,
+            image: selectedClothDetail.flattenImageUrl || selectedClothDetail.image || selectedClothDetail.imageUrl,
             name: selectedClothDetail.name || selectedClothDetail.subCategory,
           }}
           onClose={() => setSelectedClothDetail(null)}


### PR DESCRIPTION
## 📋 개요

피드 페이지에서 옷 태그를 누르면 펴기 전 이미지로 보이는 문제를 수정합니다.

## 🔧 변경 사항

### ClothDetailModal.jsx
- 의상 상세 모달 이미지 표시 로직 수정

### PostDetailPage.jsx
- 피드 상세 페이지 의상 이미지 표시 로직 개선

## 📁 변경된 파일

| 파일 | 변경 내용 |
|------|----------|
| `closzIT-front/src/components/ClothDetailModal.jsx` | 모달 이미지 표시 수정 |
| `closzIT-front/src/pages/PostDetailPage.jsx` | 이미지 표시 로직 개선 |

## ✅ 테스트

- [ ] 피드 페이지에서 옷 태그 클릭 시 올바른 이미지 표시 확인
