### PR TITLE
feat(vto): VTO 결과물 캐시 및 DB 저장 기능 구현

### DIFF
--- a/closzIT-back/prisma/migrations/20260116173818_add_vto_cache/migration.sql
+++ b/closzIT-back/prisma/migrations/20260116173818_add_vto_cache/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "vto_cache" (
+    "id" TEXT NOT NULL DEFAULT gen_random_uuid(),
+    "hash_key" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "post_id" TEXT NOT NULL,
+    "clothing_ids" TEXT[],
+    "s3_url" TEXT NOT NULL,
+    "is_visible" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "vto_cache_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "vto_cache_hash_key_key" ON "vto_cache"("hash_key");
+
+-- CreateIndex
+CREATE INDEX "vto_cache_hash_key_idx" ON "vto_cache"("hash_key");
+
+-- CreateIndex
+CREATE INDEX "vto_cache_user_id_is_visible_created_at_idx" ON "vto_cache"("user_id", "is_visible", "created_at" DESC);
+
+-- AddForeignKey
+ALTER TABLE "vto_cache" ADD CONSTRAINT "vto_cache_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/closzIT-back/prisma/schema/user.prisma
+++ b/closzIT-back/prisma/schema/user.prisma
@@ -83,7 +83,10 @@ model User {
   adminCreditActions CreditHistory[] @relation("AdminCreditActions")
 
   /// 카카오페이 결제 기록
-  KakaoPayments KakaoPayment[]
+  KakaoPayments      KakaoPayment[]
+
+  /// VTO 전체 입어보기 캐시
+  vtoCaches          VtoCache[]
 
   @@map("users")
 }

--- a/closzIT-back/prisma/schema/vto-cache.prisma
+++ b/closzIT-back/prisma/schema/vto-cache.prisma
@@ -1,0 +1,34 @@
+// VTO 전체 입어보기 결과 캐시 테이블
+
+model VtoCache {
+  /// 고유 ID (자동 생성 UUID)
+  id          String   @id @default(dbgenerated("gen_random_uuid()"))
+  
+  /// 조합 해시 (userId + modelImageHash + sorted(clothingIds))
+  hashKey     String   @unique @map("hash_key")
+  
+  /// 요청자 ID
+  userId      String   @map("user_id")
+  
+  /// SNS 게시글 ID
+  postId      String   @map("post_id")
+  
+  /// 착장한 의상 ID 배열
+  clothingIds String[] @map("clothing_ids")
+  
+  /// S3 이미지 URL
+  s3Url       String   @map("s3_url")
+  
+  /// 보여주기 여부 (Soft Delete용)
+  isVisible   Boolean  @default(true) @map("is_visible")
+  
+  /// 생성일
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  /// User 관계
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([hashKey])
+  @@index([userId, isVisible, createdAt(sort: Desc)])
+  @@map("vto_cache")
+}

--- a/closzIT-back/src/fitting/fitting.controller.ts
+++ b/closzIT-back/src/fitting/fitting.controller.ts
@@ -1,6 +1,9 @@
 import {
   Controller,
   Post,
+  Get,
+  Patch,
+  Param,
   UseInterceptors,
   UploadedFiles,
   BadRequestException,
@@ -9,6 +12,7 @@ import {
   Request,
   Logger,
 } from '@nestjs/common';
+import * as crypto from 'crypto';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import { FittingService } from './fitting.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -31,7 +35,7 @@ export class FittingController {
     private readonly prisma: PrismaService,
     private readonly vtonCacheService: VtonCacheService,
     private readonly s3Service: S3Service,
-    @InjectQueue('vto-queue') private readonly vtoQueue: Queue,
+    @InjectQueue(process.env.VTO_QUEUE_NAME || 'vto-queue') private readonly vtoQueue: Queue,
   ) {
     // S3 Client 초기화
     this.s3Client = new S3Client({
@@ -188,6 +192,43 @@ export class FittingController {
 
     const clothingIds = [body.outerId, body.topId, body.bottomId, body.shoesId].filter((id): id is string => !!id);
     
+    // 해시 키 생성 (캐싱용) - 2개 이상 선택 시에만
+    let hashKey: string | undefined;
+    const sortedClothingIds = [...clothingIds].sort();
+    
+    if (clothingIds.length >= 1) {
+      const modelHash = crypto.createHash('md5').update(user.fullBodyImage).digest('hex').slice(0, 8);
+      hashKey = crypto.createHash('sha256')
+        .update(`${userId}:${modelHash}:${sortedClothingIds.join(',')}`)
+        .digest('hex');
+
+      // 캐시 조회 (isVisible 무관 - 캐시 용도)
+      const cachedResult = await this.prisma.vtoCache.findUnique({
+        where: { hashKey },
+      });
+
+      if (cachedResult) {
+        this.logger.log(`[VTO Cache] Cache hit for partial VTO hashKey: ${hashKey.slice(0, 16)}...`);
+        
+        // 캐시 히트 시 isVisible을 true로 업데이트 (삭제 후 재요청 시 다시 보이도록)
+        if (cachedResult.isVisible !== true) {
+          await this.prisma.vtoCache.update({
+            where: { hashKey },
+            data: { isVisible: true },
+          });
+        }
+
+        const presignedUrl = await this.s3Service.convertToPresignedUrl(cachedResult.s3Url);
+        return {
+          success: true,
+          cached: true,
+          imageUrl: presignedUrl,
+          message: '캐시된 결과를 반환합니다.',
+        };
+      }
+      this.logger.log(`[VTO Cache] Cache miss for partial VTO hashKey: ${hashKey.slice(0, 16)}...`);
+    }
+
     if (clothingIds.length > 0) {
       const clothes = await this.prisma.clothing.findMany({
         where: {
@@ -220,7 +261,7 @@ export class FittingController {
 
     console.log('Clothing URLs found:', Object.keys(clothingUrls));
 
-    // 큐에 VTO 작업 등록 (즉시 jobId 반환)
+    // 큐에 VTO 작업 등록 (hashKey, clothingIds 포함)
     this.logger.log(`[VTO Queue] Queuing partial VTO for user ${userId}`);
     
     try {
@@ -229,6 +270,8 @@ export class FittingController {
         personImageUrl: user.fullBodyImage,
         clothingUrls,
         type: 'partial-try-on-by-ids',
+        hashKey,                    // 캐시 저장용 (2개 이상일 때만)
+        clothingIds: sortedClothingIds,  // 캐시 저장용
       }, {
         removeOnComplete: { age: 300, count: 100 },
         removeOnFail: { age: 3600 },
@@ -462,13 +505,49 @@ export class FittingController {
       });
     }
 
+    // clothingIds 추출 및 해시 키 생성
+    const clothingIds = allPostClothes.map(pc => pc.clothing.id).sort();
+    const modelHash = crypto.createHash('md5').update(user.fullBodyImage).digest('hex').slice(0, 8);
+    const hashKey = crypto.createHash('sha256')
+      .update(`${userId}:${modelHash}:${clothingIds.join(',')}`)
+      .digest('hex');
+
+    // DB 캐시 조회 (isVisible 무관 - 캐시 용도)
+    const cachedResult = await this.prisma.vtoCache.findUnique({
+      where: { hashKey },
+    });
+
+    if (cachedResult) {
+      this.logger.log(`[VTO Cache] Cache hit for hashKey: ${hashKey.slice(0, 16)}...`);
+      
+      // 캐시 히트 시 isVisible을 true로 업데이트 (삭제 후 재요청 시 다시 보이도록)
+      if (cachedResult.isVisible !== true) {
+        await this.prisma.vtoCache.update({
+          where: { hashKey },
+          data: { isVisible: true },
+        });
+      }
+
+      // S3 URL을 Pre-signed URL로 변환
+      const presignedUrl = await this.s3Service.convertToPresignedUrl(cachedResult.s3Url);
+      return {
+        success: true,
+        cached: true,
+        imageUrl: presignedUrl,
+        postId: body.postId,
+        message: '캐시된 결과를 반환합니다.',
+      };
+    }
+
+    this.logger.log(`[VTO Cache] Cache miss for hashKey: ${hashKey.slice(0, 16)}...`);
+
     // 카테고리별 clothingUrls 구성
     const categoryMap: Record<string, string> = {
-      'top': 'top',       // DB에서 "Top"으로 저장된 경우
+      'top': 'top',
       'tops': 'top',
-      'outer': 'outer',   // DB에서 "Outer"로 저장된 경우
+      'outer': 'outer',
       'outerwear': 'outer',
-      'bottom': 'bottom', // DB에서 "Bottom"으로 저장된 경우
+      'bottom': 'bottom',
       'bottoms': 'bottom',
       'shoes': 'shoes',
     };
@@ -491,7 +570,7 @@ export class FittingController {
       }
     }
 
-    // 큐에 VTO 작업 등록
+    // 큐에 VTO 작업 등록 (hashKey와 clothingIds 포함)
     this.logger.log(`[VTO Queue] Queuing SNS Full VTO for user ${userId}, postId: ${body.postId}`);
     
     try {
@@ -501,9 +580,11 @@ export class FittingController {
         clothingUrls,
         type: 'sns-full-try-on',
         postId: body.postId,
+        hashKey,         // 캐시 저장용
+        clothingIds,     // 캐시 저장용
       }, {
-        removeOnComplete: { age: 300, count: 100 }, // 5분간 또는 100개까지 보존
-        removeOnFail: { age: 3600 }, // 실패는 1시간 보존
+        removeOnComplete: { age: 300, count: 100 },
+        removeOnFail: { age: 3600 },
       });
 
       this.logger.log(`[VTO Queue] Job ${job.id} queued for user ${userId}`);
@@ -759,6 +840,72 @@ export class FittingController {
       this.logger.error(`Error fetching image from ${url}:`, error);
       throw error;
     }
+  }
+
+  // ========== VTO 캐시 관련 API ==========
+
+  /**
+   * VTO History 조회 (isVisible=true인 결과만)
+   * GET /api/fitting/vto-history
+   */
+  @Get('vto-history')
+  async getVtoHistory(@Request() req) {
+    const userId = req.user.id;
+    
+    const results = await this.prisma.vtoCache.findMany({
+      where: {
+        userId,
+        isVisible: true,
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 20,
+    });
+
+    // S3 URL을 Pre-signed URL로 변환
+    const resultsWithPresignedUrls = await Promise.all(
+      results.map(async (result) => ({
+        id: result.id,
+        postId: result.postId,
+        imageUrl: await this.s3Service.convertToPresignedUrl(result.s3Url),
+        createdAt: result.createdAt,
+      }))
+    );
+
+    return {
+      success: true,
+      results: resultsWithPresignedUrls,
+    };
+  }
+
+  /**
+   * VTO 결과 숨기기 (Soft Delete)
+   * PATCH /api/fitting/vto/:id/hide
+   */
+  @Patch('vto/:id/hide')
+  async hideVtoResult(@Request() req, @Param('id') id: string) {
+    const userId = req.user.id;
+
+    // 소유권 확인
+    const vtoCache = await this.prisma.vtoCache.findUnique({
+      where: { id },
+    });
+
+    if (!vtoCache || vtoCache.userId !== userId) {
+      throw new BadRequestException({
+        success: false,
+        message: 'VTO 결과를 찾을 수 없습니다.',
+      });
+    }
+
+    await this.prisma.vtoCache.update({
+      where: { id },
+      data: { isVisible: false },
+    });
+
+    return {
+      success: true,
+      message: 'VTO 결과가 숨겨졌습니다.',
+    };
   }
 }
 

--- a/closzIT-back/src/fitting/fitting.module.ts
+++ b/closzIT-back/src/fitting/fitting.module.ts
@@ -13,7 +13,7 @@ import { VtonCacheModule } from '../vton-cache/vton-cache.module';
     PrismaModule,
     S3Module,
     forwardRef(() => VtonCacheModule),
-    BullModule.registerQueue({ name: 'vto-queue' }),
+    BullModule.registerQueue({ name: process.env.VTO_QUEUE_NAME || 'vto-queue' }),
   ],
   controllers: [FittingController],
   providers: [FittingService],

--- a/closzIT-back/src/queue/processors/vto.processor.ts
+++ b/closzIT-back/src/queue/processors/vto.processor.ts
@@ -1,7 +1,9 @@
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
-import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
+import { Injectable, Logger, Inject, forwardRef, OnModuleInit } from '@nestjs/common';
 import { FittingService } from '../../fitting/fitting.service';
+import { S3Service } from '../../s3/s3.service';
+import { PrismaService } from '../../prisma/prisma.service';
 
 interface VtoJobData {
     userId: string;
@@ -12,26 +14,47 @@ interface VtoJobData {
         bottom?: string;
         shoes?: string;
     };
-    type?: string; // 'partial-try-on-by-ids' | 'sns-virtual-try-on'
+    type?: string; // 'partial-try-on-by-ids' | 'sns-virtual-try-on' | 'sns-full-try-on'
     postId?: string; // SNS VTO인 경우
+    hashKey?: string; // 캐시 저장용 (sns-full-try-on)
+    clothingIds?: string[]; // 캐시 저장용 (sns-full-try-on)
 }
 
 @Injectable()
-@Processor('vto-queue', {
+@Processor(process.env.VTO_QUEUE_NAME || 'vto-queue', {
     concurrency: 3, // 동시에 3개 작업 처리
 })
-export class VtoProcessor extends WorkerHost {
+export class VtoProcessor extends WorkerHost implements OnModuleInit {
     private readonly logger = new Logger(VtoProcessor.name);
 
     constructor(
         @Inject(forwardRef(() => FittingService))
         private readonly fittingService: FittingService,
+        private readonly s3Service: S3Service,
+        private readonly prisma: PrismaService,
     ) {
         super();
+        this.logger.log('[VTO Worker] VtoProcessor initialized and ready to process jobs');
+    }
+
+    async onModuleInit() {
+        // BullMQ 워커 이벤트 리스너 등록
+        const worker = this.worker;
+
+        if (worker) {
+            worker.on('failed', (job, error) => {
+                this.logger.error(`[VTO Worker] Job ${job?.id} failed: ${error.message}`);
+            });
+
+            worker.on('error', (error) => {
+                this.logger.error(`[VTO Worker] Worker error: ${error.message}`);
+            });
+        }
     }
 
     async process(job: Job<VtoJobData>): Promise<any> {
-        const { userId, personImageUrl, clothingUrls, type, postId } = job.data;
+        const { userId, personImageUrl, clothingUrls, type, postId, hashKey, clothingIds } = job.data;
+
 
         this.logger.log(`[VTO Worker] Processing job ${job.id} for user ${userId}, type: ${type || 'unknown'}`);
 
@@ -50,6 +73,65 @@ export class VtoProcessor extends WorkerHost {
                     clothingUrls,
                     userId,
                 );
+
+                await job.updateProgress(80);
+
+                // 디버그: 캐싱 조건 확인
+                this.logger.log(`[VTO Worker] Job ${job.id} cache check - hashKey: ${hashKey ? 'exists' : 'null'}, clothingIds: ${clothingIds ? `${clothingIds.length} items` : 'null'}, type: ${type}`);
+
+                // hashKey가 있으면 S3 업로드 + DB 저장 (sns-full-try-on, partial-try-on-by-ids 모두)
+                if (hashKey && clothingIds && clothingIds.length >= 1) {
+                    try {
+                        // Base64 이미지를 S3에 업로드 (closzit-ai-results 버킷)
+                        const imageBase64 = result.imageUrl.replace(/^data:image\/\w+;base64,/, '');
+                        const s3Key = `vto/${userId}/${hashKey}.png`;
+                        const s3Url = await this.s3Service.uploadBase64Image(
+                            imageBase64,
+                            s3Key,
+                            'image/png',
+                            'closzit-ai-results'
+                        );
+
+                        this.logger.log(`[VTO Worker] S3 upload complete: ${s3Key}`);
+
+                        // DB에 캐시 저장 (upsert로 중복 hashKey 처리)
+                        await this.prisma.vtoCache.upsert({
+                            where: { hashKey },
+                            update: {
+                                s3Url,  // 새 이미지로 업데이트
+                                isVisible: true,  // 다시 보이도록
+                            },
+                            create: {
+                                hashKey,
+                                userId,
+                                postId: postId || 'direct-fitting',
+                                clothingIds,
+                                s3Url,
+                                isVisible: true,
+                            },
+                        });
+
+                        this.logger.log(`[VTO Worker] DB cache saved for hashKey: ${hashKey.slice(0, 16)}...`);
+
+                        // S3 URL을 Pre-signed URL로 변환하여 반환
+                        const presignedUrl = await this.s3Service.convertToPresignedUrl(s3Url);
+
+                        await job.updateProgress(100);
+                        this.logger.log(`[VTO Worker] Job ${job.id} completed successfully on attempt ${attempt}`);
+
+                        return {
+                            success: true,
+                            imageUrl: presignedUrl,
+                            postId,
+                            appliedClothing: result.appliedClothing,
+                        };
+                    } catch (saveError) {
+                        // 저장 실패해도 결과는 반환 (캐싱 실패만 로그)
+                        this.logger.error(`[VTO Worker] Cache save failed: ${saveError.message}`);
+                        await job.updateProgress(100);
+                        return { ...result, postId };
+                    }
+                }
 
                 await job.updateProgress(100);
 

--- a/closzIT-back/src/queue/queue.module.ts
+++ b/closzIT-back/src/queue/queue.module.ts
@@ -6,6 +6,8 @@ import { FlattenProcessor } from './processors/flatten.processor';
 import { VtoProcessor } from './processors/vto.processor';
 import { AnalysisModule } from '../analysis/analysis.module';
 import { FittingModule } from '../fitting/fitting.module';
+import { S3Module } from '../s3/s3.module';
+import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
     imports: [
@@ -21,10 +23,12 @@ import { FittingModule } from '../fitting/fitting.module';
         }),
         BullModule.registerQueue(
             { name: 'flatten-queue' },
-            { name: 'vto-queue' },
+            { name: process.env.VTO_QUEUE_NAME || 'vto-queue' },
         ),
         forwardRef(() => AnalysisModule),
         forwardRef(() => FittingModule),
+        S3Module,
+        PrismaModule,
     ],
     controllers: [QueueController],
     providers: [FlattenProcessor, VtoProcessor],


### PR DESCRIPTION
## 개요

VTO(Virtual Try-On) 결과물을 캐시하고 DB에 저장하는 기능을 구현합니다.

## 변경 사항

### Backend (NestJS)

#### Database
- **vto_caches 테이블 마이그레이션 추가**: VTO 결과물을 캐시하기 위한 새로운 테이블 생성
- **Prisma 스키마 업데이트**: `vto-cache.prisma` 추가 및 `user.prisma` 관계 설정

#### Services & Controllers
- **VtoProcessor**: S3 업로드 및 DB 저장 로직 구현
- **S3Service**: VTO 결과용 presigned URL 생성 메서드 추가
- **FittingController**: 캐시된 VTO 결과 조회 API 추가
- **QueueController/Module**: VTO 큐 관련 설정 업데이트

### Frontend (React)
- **vtoStore.js**: 캐시된 VTO 결과를 활용하도록 개선

## 변경된 파일

| 파일 | 변경 내용 |
|------|----------|
| `prisma/migrations/.../migration.sql` | VTO 캐시 테이블 마이그레이션 |
| `prisma/schema/user.prisma` | 사용자-VTO 캐시 관계 추가 |
| `prisma/schema/vto-cache.prisma` | VTO 캐시 스키마 정의 |
| `fitting/fitting.controller.ts` | 캐시 조회 API 추가 |
| `fitting/fitting.module.ts` | 모듈 설정 업데이트 |
| `queue/processors/vto.processor.ts` | S3 업로드 및 DB 저장 로직 |
| `queue/queue.controller.ts` | 큐 컨트롤러 업데이트 |
| `queue/queue.module.ts` | 큐 모듈 설정 업데이트 |
| `s3/s3.service.ts` | VTO presigned URL 메서드 추가 |
| `stores/vtoStore.js` | 캐시 활용 로직 구현 |

## 머지 가이드라인

- [ ] dev 브랜치에 머지 후 Prisma 마이그레이션 실행 필요: `npx prisma migrate deploy`
