### PR TITLE
style(frontend): UI 미세 조정

### DIFF
--- a/closzIT-front/src/components/BottomNav.jsx
+++ b/closzIT-front/src/components/BottomNav.jsx
@@ -122,7 +122,7 @@ const BottomNav = ({ floatingAction }) => {
       )}
 
       {/* Bottom Navigation - 3 buttons */}
-      <div className="fixed bottom-0 left-0 right-0 h-24 glass-warm border-t border-gold-light/20 flex items-center justify-evenly gap-16 px-4 z-50 safe-area-pb">
+      <div className="fixed bottom-0 left-0 right-0 h-20 glass-warm border-t border-gold-light/20 flex items-center justify-evenly gap-16 px-4 z-50 safe-area-pb">
         {/* 내 옷장 */}
         <button
           onClick={() => handleTabClick(TAB_KEYS.MAIN, '/main')}
@@ -132,7 +132,7 @@ const BottomNav = ({ floatingAction }) => {
               : 'text-charcoal-light dark:text-cream-dark hover:text-gold'
           }`}
         >
-          <span className="material-symbols-rounded text-[42px]">person</span>
+          <span className="material-symbols-rounded text-[30px]">person</span>
           <span className="text-[16px] font-semibold">Me</span>
         </button>
 
@@ -145,7 +145,7 @@ const BottomNav = ({ floatingAction }) => {
               : 'text-charcoal-light dark:text-cream-dark hover:text-gold'
           }`}
         >
-          <span className="material-symbols-rounded text-[42px]">styler</span>
+          <span className="material-symbols-rounded text-[30px]">styler</span>
           <span className="text-[16px] font-semibold">옷장&피팅룸</span>
         </button>
 
@@ -158,7 +158,7 @@ const BottomNav = ({ floatingAction }) => {
               : 'text-charcoal-light dark:text-cream-dark hover:text-gold'
           }`}
         >
-          <span className="material-symbols-rounded text-[42px]">grid_view</span>
+          <span className="material-symbols-rounded text-[30px]">grid_view</span>
           <span className="text-[16px] font-semibold">SNS</span>
         </button>
       </div>

--- a/closzIT-front/src/pages/Main/MainPage2.jsx
+++ b/closzIT-front/src/pages/Main/MainPage2.jsx
@@ -323,7 +323,7 @@ const MainPage2 = ({ hideHeader = false }) => {
                       : 'translate-y-0 opacity-100'
                       } text-charcoal-light dark:text-cream-dark gap-1`}
                   >
-                    오늘 뱀 입지? <span className="text-gold font-semibold">AI에게 추천받기</span>
+                    오늘 뭐 입지? <span className="text-gold font-semibold">AI에게 추천받기</span>
                   </span>
                 </div>
                 <span className="material-symbols-rounded text-gold text-lg md:text-xl absolute right-4">search</span>
@@ -434,8 +434,8 @@ const MainPage2 = ({ hideHeader = false }) => {
                         text: {
                           fontFamily: "'Pretendard', 'Noto Sans KR', sans-serif",
                           fontSize: 16,
-                          fontWeight: 600,
-                          fill: '#4A4A4A',
+                          fontWeight: 700,
+                          fill: '#FFFFFF',
                         },
                       },
                     }}
@@ -458,7 +458,7 @@ const MainPage2 = ({ hideHeader = false }) => {
                     arcLinkLabelsThickness={2}
                     arcLinkLabelsColor={{ from: 'color' }}
                     arcLabelsSkipAngle={10}
-                    arcLabelsTextColor={{ from: 'color', modifiers: [['darker', 2]] }}
+                    arcLabelsTextColor="#FFFFFF"
                     arcLabel={d => d.value}
                     tooltip={({ datum }) => (
                       <div className="bg-white px-2 py-1 rounded shadow-lg text-xs font-medium">


### PR DESCRIPTION
# UI 미세 조정

## 📋 변경 사항

### BottomNav
- 높이: `h-24` → `h-20`으로 조정
- 아이콘 크기: `text-[42px]` → `text-[30px]`으로 조정

### MainPage2
- 검색창 오타 수정: `'뱀'` → `'뭐'` (오늘 뭐 입지?)
- 파이 차트 숫자 스타일 변경:
  - `fontWeight`: 600 → 700 (bold)
  - `fill`: `#4A4A4A` → `#FFFFFF` (하얀색)
  - `arcLabelsTextColor`: `#FFFFFF` (하얀색)

## 📁 변경된 파일
- `closzIT-front/src/components/BottomNav.jsx`
- `closzIT-front/src/pages/Main/MainPage2.jsx`

## ✅ 테스트
- BottomNav 크기 조정 확인
- 파이 차트 숫자가 하얀색 bold로 표시되는지 확인

## 🔀 머지 가이드라인
- `dev` 브랜치로 머지
